### PR TITLE
Add fraud detection 5V analysis notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+.ipynb_checkpoints/
+.env
+.venv
+build/
+*.pyc
+data/

--- a/Fraud_Detection_5V.ipynb
+++ b/Fraud_Detection_5V.ipynb
@@ -1,0 +1,2748 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "10d3c347",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# Анализ 5V для сценария Fraud Detection\n",
+    "\n",
+    "Выбран датасет [Credit Card Fraud Detection](https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud) и бизнес-сценарий Fraud Detection: необходимо снизить количество мошеннических транзакций на 30% при ограничении задержки обработки до 50 мс и поддержке обработки late-arriving данных.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0be7a0ac",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Организация работы и воспроизводимость\n",
+    "- Для запуска ноутбука требуется предварительно скачать файл `creditcard.csv` из датасета Kaggle и разместить его в папке `data/`.\n",
+    "- В примерах используются библиотеки `pandas`, `numpy`, `pyarrow`, `fastavro`, `seaborn`, `matplotlib`, `great_expectations` и `scikit-learn`. При отсутствии их можно установить командой `pip install -r requirements.txt` (см. список в разделе импорта).\n",
+    "- Все расчёты выполняются на оригинальном датасете без семплирования, чтобы сохранить дисбаланс классов, критичный для fraud detection.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5f9fe8d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:01.628482Z",
+     "iopub.status.busy": "2025-09-18T11:03:01.628162Z",
+     "iopub.status.idle": "2025-09-18T11:03:10.823861Z",
+     "shell.execute_reply": "2025-09-18T11:03:10.822938Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Time</th>\n",
+       "      <th>V1</th>\n",
+       "      <th>V2</th>\n",
+       "      <th>V3</th>\n",
+       "      <th>V4</th>\n",
+       "      <th>V5</th>\n",
+       "      <th>V6</th>\n",
+       "      <th>V7</th>\n",
+       "      <th>V8</th>\n",
+       "      <th>V9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>V21</th>\n",
+       "      <th>V22</th>\n",
+       "      <th>V23</th>\n",
+       "      <th>V24</th>\n",
+       "      <th>V25</th>\n",
+       "      <th>V26</th>\n",
+       "      <th>V27</th>\n",
+       "      <th>V28</th>\n",
+       "      <th>Amount</th>\n",
+       "      <th>Class</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>-1.359807</td>\n",
+       "      <td>-0.072781</td>\n",
+       "      <td>2.536347</td>\n",
+       "      <td>1.378155</td>\n",
+       "      <td>-0.338321</td>\n",
+       "      <td>0.462388</td>\n",
+       "      <td>0.239599</td>\n",
+       "      <td>0.098698</td>\n",
+       "      <td>0.363787</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.018307</td>\n",
+       "      <td>0.277838</td>\n",
+       "      <td>-0.110474</td>\n",
+       "      <td>0.066928</td>\n",
+       "      <td>0.128539</td>\n",
+       "      <td>-0.189115</td>\n",
+       "      <td>0.133558</td>\n",
+       "      <td>-0.021053</td>\n",
+       "      <td>149.62</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.191857</td>\n",
+       "      <td>0.266151</td>\n",
+       "      <td>0.166480</td>\n",
+       "      <td>0.448154</td>\n",
+       "      <td>0.060018</td>\n",
+       "      <td>-0.082361</td>\n",
+       "      <td>-0.078803</td>\n",
+       "      <td>0.085102</td>\n",
+       "      <td>-0.255425</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.225775</td>\n",
+       "      <td>-0.638672</td>\n",
+       "      <td>0.101288</td>\n",
+       "      <td>-0.339846</td>\n",
+       "      <td>0.167170</td>\n",
+       "      <td>0.125895</td>\n",
+       "      <td>-0.008983</td>\n",
+       "      <td>0.014724</td>\n",
+       "      <td>2.69</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>-1.358354</td>\n",
+       "      <td>-1.340163</td>\n",
+       "      <td>1.773209</td>\n",
+       "      <td>0.379780</td>\n",
+       "      <td>-0.503198</td>\n",
+       "      <td>1.800499</td>\n",
+       "      <td>0.791461</td>\n",
+       "      <td>0.247676</td>\n",
+       "      <td>-1.514654</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.247998</td>\n",
+       "      <td>0.771679</td>\n",
+       "      <td>0.909412</td>\n",
+       "      <td>-0.689281</td>\n",
+       "      <td>-0.327642</td>\n",
+       "      <td>-0.139097</td>\n",
+       "      <td>-0.055353</td>\n",
+       "      <td>-0.059752</td>\n",
+       "      <td>378.66</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>-0.966272</td>\n",
+       "      <td>-0.185226</td>\n",
+       "      <td>1.792993</td>\n",
+       "      <td>-0.863291</td>\n",
+       "      <td>-0.010309</td>\n",
+       "      <td>1.247203</td>\n",
+       "      <td>0.237609</td>\n",
+       "      <td>0.377436</td>\n",
+       "      <td>-1.387024</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.108300</td>\n",
+       "      <td>0.005274</td>\n",
+       "      <td>-0.190321</td>\n",
+       "      <td>-1.175575</td>\n",
+       "      <td>0.647376</td>\n",
+       "      <td>-0.221929</td>\n",
+       "      <td>0.062723</td>\n",
+       "      <td>0.061458</td>\n",
+       "      <td>123.50</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>-1.158233</td>\n",
+       "      <td>0.877737</td>\n",
+       "      <td>1.548718</td>\n",
+       "      <td>0.403034</td>\n",
+       "      <td>-0.407193</td>\n",
+       "      <td>0.095921</td>\n",
+       "      <td>0.592941</td>\n",
+       "      <td>-0.270533</td>\n",
+       "      <td>0.817739</td>\n",
+       "      <td>...</td>\n",
+       "      <td>-0.009431</td>\n",
+       "      <td>0.798278</td>\n",
+       "      <td>-0.137458</td>\n",
+       "      <td>0.141267</td>\n",
+       "      <td>-0.206010</td>\n",
+       "      <td>0.502292</td>\n",
+       "      <td>0.219422</td>\n",
+       "      <td>0.215153</td>\n",
+       "      <td>69.99</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 31 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Time        V1        V2        V3        V4        V5        V6        V7  \\\n",
+       "0   0.0 -1.359807 -0.072781  2.536347  1.378155 -0.338321  0.462388  0.239599   \n",
+       "1   0.0  1.191857  0.266151  0.166480  0.448154  0.060018 -0.082361 -0.078803   \n",
+       "2   1.0 -1.358354 -1.340163  1.773209  0.379780 -0.503198  1.800499  0.791461   \n",
+       "3   1.0 -0.966272 -0.185226  1.792993 -0.863291 -0.010309  1.247203  0.237609   \n",
+       "4   2.0 -1.158233  0.877737  1.548718  0.403034 -0.407193  0.095921  0.592941   \n",
+       "\n",
+       "         V8        V9  ...       V21       V22       V23       V24       V25  \\\n",
+       "0  0.098698  0.363787  ... -0.018307  0.277838 -0.110474  0.066928  0.128539   \n",
+       "1  0.085102 -0.255425  ... -0.225775 -0.638672  0.101288 -0.339846  0.167170   \n",
+       "2  0.247676 -1.514654  ...  0.247998  0.771679  0.909412 -0.689281 -0.327642   \n",
+       "3  0.377436 -1.387024  ... -0.108300  0.005274 -0.190321 -1.175575  0.647376   \n",
+       "4 -0.270533  0.817739  ... -0.009431  0.798278 -0.137458  0.141267 -0.206010   \n",
+       "\n",
+       "        V26       V27       V28  Amount  Class  \n",
+       "0 -0.189115  0.133558 -0.021053  149.62      0  \n",
+       "1  0.125895 -0.008983  0.014724    2.69      0  \n",
+       "2 -0.139097 -0.055353 -0.059752  378.66      0  \n",
+       "3 -0.221929  0.062723  0.061458  123.50      0  \n",
+       "4  0.502292  0.219422  0.215153   69.99      0  \n",
+       "\n",
+       "[5 rows x 31 columns]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "from pathlib import Path\n",
+    "import math\n",
+    "from io import BytesIO\n",
+    "import json\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "from fastavro import writer, parse_schema\n",
+    "\n",
+    "import great_expectations as ge\n",
+    "from great_expectations.execution_engine import PandasExecutionEngine\n",
+    "from great_expectations.validator.validator import Validator\n",
+    "from great_expectations.core.batch import Batch\n",
+    "\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "plt.style.use('seaborn-v0_8')\n",
+    "sns.set_theme(style='whitegrid')\n",
+    "\n",
+    "DATA_PATH = Path('data/creditcard.csv')\n",
+    "if not DATA_PATH.exists():\n",
+    "    raise FileNotFoundError('Файл data/creditcard.csv не найден. Скачайте датасет с Kaggle и поместите в папку data/.')\n",
+    "\n",
+    "df = pd.read_csv(DATA_PATH)\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9baef68",
+   "metadata": {},
+   "source": [
+    "## 1. Volume (объём данных)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "be1c656d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:10.826655Z",
+     "iopub.status.busy": "2025-09-18T11:03:10.826390Z",
+     "iopub.status.idle": "2025-09-18T11:03:19.963033Z",
+     "shell.execute_reply": "2025-09-18T11:03:19.962141Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Размер, МБ</th>\n",
+       "      <th>Коэффициент сжатия к CSV</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Формат</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>CSV</th>\n",
+       "      <td>143.84</td>\n",
+       "      <td>1.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Parquet (Snappy)</th>\n",
+       "      <td>69.84</td>\n",
+       "      <td>0.486</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Avro</th>\n",
+       "      <td>65.55</td>\n",
+       "      <td>0.456</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  Размер, МБ  Коэффициент сжатия к CSV\n",
+       "Формат                                                \n",
+       "CSV                   143.84                     1.000\n",
+       "Parquet (Snappy)       69.84                     0.486\n",
+       "Avro                   65.55                     0.456"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "num_rows, num_cols = df.shape\n",
+    "csv_size_bytes = DATA_PATH.stat().st_size\n",
+    "avg_bytes_per_row = csv_size_bytes / num_rows\n",
+    "\n",
+    "parquet_buffer = BytesIO()\n",
+    "pq.write_table(pa.Table.from_pandas(df), parquet_buffer, compression='snappy')\n",
+    "parquet_size_bytes = parquet_buffer.getbuffer().nbytes\n",
+    "\n",
+    "avro_fields = []\n",
+    "for col, dtype in zip(df.columns, df.dtypes):\n",
+    "    if np.issubdtype(dtype, np.integer):\n",
+    "        avro_type = 'long'\n",
+    "    else:\n",
+    "        avro_type = 'double'\n",
+    "    avro_fields.append({'name': col, 'type': avro_type})\n",
+    "\n",
+    "avro_schema = {\n",
+    "    'doc': 'Credit card transaction record',\n",
+    "    'name': 'CreditCardRecord',\n",
+    "    'namespace': 'fraud',\n",
+    "    'type': 'record',\n",
+    "    'fields': avro_fields,\n",
+    "}\n",
+    "\n",
+    "avro_buffer = BytesIO()\n",
+    "writer(avro_buffer, parse_schema(avro_schema), df.to_dict('records'))\n",
+    "avro_size_bytes = avro_buffer.getbuffer().nbytes\n",
+    "\n",
+    "storage_formats = pd.DataFrame([\n",
+    "    {\n",
+    "        'Формат': 'CSV',\n",
+    "        'Размер, МБ': csv_size_bytes / 1024**2,\n",
+    "        'Коэффициент сжатия к CSV': 1.0,\n",
+    "    },\n",
+    "    {\n",
+    "        'Формат': 'Parquet (Snappy)',\n",
+    "        'Размер, МБ': parquet_size_bytes / 1024**2,\n",
+    "        'Коэффициент сжатия к CSV': parquet_size_bytes / csv_size_bytes,\n",
+    "    },\n",
+    "    {\n",
+    "        'Формат': 'Avro',\n",
+    "        'Размер, МБ': avro_size_bytes / 1024**2,\n",
+    "        'Коэффициент сжатия к CSV': avro_size_bytes / csv_size_bytes,\n",
+    "    },\n",
+    "]).set_index('Формат')\n",
+    "\n",
+    "volume_stats = {\n",
+    "    'csv_size_bytes': csv_size_bytes,\n",
+    "    'parquet_size_bytes': parquet_size_bytes,\n",
+    "    'avro_size_bytes': avro_size_bytes,\n",
+    "    'avg_bytes_per_row': avg_bytes_per_row,\n",
+    "}\n",
+    "\n",
+    "storage_formats.round({'Размер, МБ': 2, 'Коэффициент сжатия к CSV': 3})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "29672f17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:19.966357Z",
+     "iopub.status.busy": "2025-09-18T11:03:19.966030Z",
+     "iopub.status.idle": "2025-09-18T11:03:19.990965Z",
+     "shell.execute_reply": "2025-09-18T11:03:19.989810Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>day_index</th>\n",
+       "      <th>transactions</th>\n",
+       "      <th>daily_volume_mb</th>\n",
+       "      <th>cumulative_volume_mb</th>\n",
+       "      <th>date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>144786</td>\n",
+       "      <td>73.124033</td>\n",
+       "      <td>73.124033</td>\n",
+       "      <td>2013-01-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>140021</td>\n",
+       "      <td>70.717474</td>\n",
+       "      <td>143.841507</td>\n",
+       "      <td>2013-01-02</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   day_index  transactions  daily_volume_mb  cumulative_volume_mb       date\n",
+       "0          0        144786        73.124033             73.124033 2013-01-01\n",
+       "1          1        140021        70.717474            143.841507 2013-01-02"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "seconds_per_day = 24 * 3600\n",
+    "adjusted_time = df['Time'] - df['Time'].min()\n",
+    "day_index = np.floor(adjusted_time / seconds_per_day).astype(int)\n",
+    "daily_counts = day_index.value_counts().sort_index()\n",
+    "\n",
+    "daily_volume_mb = daily_counts * volume_stats['avg_bytes_per_row'] / 1024**2\n",
+    "\n",
+    "daily_growth = (\n",
+    "    pd.DataFrame({\n",
+    "        'day_index': daily_counts.index,\n",
+    "        'transactions': daily_counts.values,\n",
+    "        'daily_volume_mb': daily_volume_mb.values,\n",
+    "    })\n",
+    "    .sort_values('day_index')\n",
+    "    .reset_index(drop=True)\n",
+    ")\n",
+    "\n",
+    "daily_growth['cumulative_volume_mb'] = daily_growth['daily_volume_mb'].cumsum()\n",
+    "start_timestamp = pd.Timestamp('2013-01-01')\n",
+    "daily_growth['date'] = start_timestamp + pd.to_timedelta(daily_growth['day_index'], unit='D')\n",
+    "\n",
+    "avg_daily_mb = daily_growth['daily_volume_mb'].mean()\n",
+    "yearly_volume_gb = avg_daily_mb * 365 / 1024\n",
+    "months_to_tb = (1024 * 1024) / avg_daily_mb / (365 / 12)\n",
+    "\n",
+    "volume_stats.update({\n",
+    "    'avg_daily_mb': avg_daily_mb,\n",
+    "    'yearly_volume_gb': yearly_volume_gb,\n",
+    "    'months_to_tb': months_to_tb,\n",
+    "})\n",
+    "\n",
+    "daily_growth\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8c4da770",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:19.994142Z",
+     "iopub.status.busy": "2025-09-18T11:03:19.993811Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.298936Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.297781Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwwAAAGACAYAAAAAkuXxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgrtJREFUeJzt3XlcFPX/B/DXLvetKDerggd4cq0niLKa5ZWpmdnx7bL0V55lan3V+pZph5qVWmZ2mHZ6VCqZ2SLe2uKteCCgy6mCnMux7M7vD2J0QxRGYDlez8ejR/KZ2dn3vlhg3jszn5EJgiCAiIiIiIjoNuTmLoCIiIiIiBouNgxERERERFQlNgxERERERFQlNgxERERERFQlNgxERERERFQlNgxERERERFQlNgxERERERFQlNgxERERERFQlNgxEREQ1VFBQgJSUFOh0unvajl6vR3Z2NkpLSwEA2dnZ97xNIqLaxoaBiIgAAIWFhfj666/Fr/Py8rBhwwbzFdSACIKAH3/8EY888giCgoIQFhaGQYMG4bfffrun7R49ehR9+/aFWq0GAPTt2xdLliypjZKJiGqNTBAEwdxFEFHjsHnzZrz22mvYuHEjunfvbrLsp59+wvz58zFo0CB88sknsLCwMFOVJJXBYIBSqcT//vc/9OzZE19++SUSExOxdu1ac5dmdi+//DKio6MxevRoDBw4EE5OTpDJZAgICICrq6vk7ebm5uLMmTMICAhAq1atcODAAXh6esLf378WqyciujeW5i6AiBq/P//8E2+++SaUSiU+/PBDNguNlIWFBaZOnYo5c+bAaDTC0dERq1evNndZZvfLL78gOjoaH3zwAUaOHFmr23ZxcUG/fv3Er2/9NxFRQ8GGgYjuyeHDh/Hyyy+jffv2+Oyzz2BjY2PukugePPvssxg2bBjS09PRvn17ODs7m7sks1u7di2GDx9e680CEVFjwWsYiEiy+Ph4vPjii3Bzc8PatWvh5OQkLvv444/RtWtXZGdnV3rc/PnzoVQqUVJSAgBQqVQICAjAO++8U2nd5557DgEBAZg0aRKA8vPsg4ODsXDhwkrrZmRkoHPnzpU+FX/yyScREBBQ6b/NmzebrPfdd99hxIgRCAoKMllvx44dd9zOrf9VCAgIwCeffGKy/S+++AIBAQF48sknxbHDhw+bPL5bt264//77sXr1atx6xugnn3yCgICASnmeOnWq0muZO3cuQkJCKuVzq3/XV7F9APD09ERISAgsLCwQHh6OgIAAHD58+I7bq3j8pUuXMH36dISGhqJ3795YuHCh+H2uUFZWhpUrV2Lw4MHo1q0bVCoVli1bJl74e6vY2Fg88cQTCAkJQWhoKMaOHYutW7cCqNn3oyq///47xowZgx49eqB3796YNWsWMjMzxeU6nQ4XLlyAl5cXXnjhBYSGhiI4OBhPPvkkNBqNuN6uXbsqPfepU6fu+vyXLl3CtGnT0KtXL3Tv3h1jxozBX3/9ZbLO5s2bxffGv7//x44du+3zaTQaTJs2DQMHDkS3bt0wYMAALFq0CMXFxXetqcLcuXNvm+ncuXNN1tu1axdeeOEFREREoFu3bhg8eDBWrlwJg8Fgst6TTz6JESNGVHqetWvXIiAgACkpKeKYSqUSf+Zv9dZbb1X6vgYEBOCtt96q8nVU5Fex/YMHDyIwMBAfffSRyXpbt25FQEAAvvvuuyq3RdRc8QgDEUly5coVTJw4EdbW1li7di3c3d1Nlo8aNQorV65EdHQ0nnjiCXG8tLQUf/zxB4YMGWJyNMLGxgZbt27F7NmzYWVlBaC8ATh48KDJeg4ODhg8eDB+//13vPbaayanP23btg2CINz2k2B/f39MnjwZAHDjxg0sXrzYZHl0dDT+97//oVevXnjiiSdgZ2eHxMREfPbZZ+I6kydPxsMPP2yyjfHjxyMsLOyueeXl5eHzzz+vcvnkyZPh7++PkpISREdHY9myZXB1dcW4cePuuu268tVXX+H69es1esyMGTPg4+ODV155BcePH8e3336LvLw8vP/+++I68+bNw5YtW3D//ffjmWeewcmTJ7F69WpcunQJK1euFNfbvHkzXn/9dXTs2BGTJk2Ck5MT4uPjsXfvXowcOfKevh8V23/ttdfQvXt3vPzyy8jKysK6detw9OhR/PLLL3B2dkZOTg4AYM2aNXBzc8Nzzz0HGxsb/Pzzz3j66afx1VdfoWfPnujWrZv4GuPi4vDjjz/e9fkvXryICRMmwMPDA88//zzs7e3x+++/46WXXsInn3yC++67z2R9uVyO3377DU8//bTJa7CxsanUlO3YsQPFxcWYMGECWrRogZMnT2L9+vXIyMjAxx9/XK18AMDa2tqkOZ83b16ldbZs2QJ7e3s888wzsLe3x6FDh/Dxxx+joKAAc+bMqfZz1Ze+ffvisccew+eff47Bgweja9euuHr1KhYuXIh+/fphwoQJ5i6RqMFhw0BENZaVlYWXX34Z169fR0REBPz8/Cqt07ZtW4SEhOC3334zaRhiY2ORm5uLUaNGmayvVCpx9uxZqNVq3H///QDKd4Z69OiBq1evmqz70EMPYevWrdi/fz8iIyPF8d9++w09e/aEt7e3yfplZWVwc3MTnzMlJaVSw/DXX3/B2dkZX3zxhdigHD582KRhCA8PF/9dsY3g4OBKr+V2Vq9eDUtLS3Tt2vW2y/v164fevXuLry8oKAhnz56963brSnZ2Nr788ktERkZiz5491X6cr68vPv30UwDA448/DkdHR3z33Xd49tlnERgYiHPnzmHLli0YN26cuCP6+OOPw9XVFV9++SUOHTqEPn36ID8/HwsXLkSPHj3w7bffmjSNFUde7uX7odfrsWTJEnTq1AkbNmwQtx8WFoZJkybh66+/xrRp02A0GgEAVlZWWL9+Pdq1awcAGDNmDIYOHYrFixdj8+bN8PT0FJ/XYDBUq2F455134OXlhU2bNsHa2hoA8Nhjj2HChAlYsmRJpYbhvvvuw6ZNm8SGoaioCNHR0bjvvvuwbds2k3VnzZoFW1tb8evx48ejbdu2WLZsGdLS0ir9jFSVkaWlpUmeb775ZqX1li5davJcEyZMwIIFC/D9999j5syZ4mtrSF599VXs27cPc+bMwebNmzF//nyUlZXhnXfegUwmM3d5RA0OT0kiohqbO3cu0tPTMWLECOzbtw+///77bdcbNWoUTpw4gStXrohjW7duhZeXF3r16mWyrpWVFUaOHGlyas2WLVswduzYStvt168f3N3dxVNTAODChQs4f/48HnzwwUrr6/X6u+60FBYWwtbWtk6uwcjMzMT69evx4osvwsHB4bbr5OfnIzs7G2lpaVizZg2MRiP69OlTab3c3FxkZ2eL/xUUFFT5vBXr/PvT5+pYtWoVnJycTE6fqo7HH3/c5OuKZrGi6YiNjQUAPPPMMybrPfvssybL9+/fj8LCQrzwwguVvie1sUN3+vRpZGVlYcKECSbbHzhwIPz9/bF7926T9QcNGiQ2CwDg6uqKMWPG4MyZM1UehSkoKKjye5STk4NDhw5h6NCh4nrZ2dm4ceMGIiIikJycbHJqFAA8+OCDSEpKEk89+uOPP+Dk5IS+fftW2v6tO/A6nQ7Z2dkICQmBIAjVbkRLS0ur9fNw63NVvBalUomioiIkJiaarGswGEzev9nZ2SgqKrrtdsvKyiqtW9V7uaSkRMyvosm7Ezs7OyxevBiXLl3C448/jt27d+O1116rViNF1BzxCAMR1Vhubi6WLVuG++67D5cuXcI777yDiIgIk2sYAGDYsGFYtGgRfvvtN0yZMgX5+fmIiYnB008/fdudvrFjx2LMmDG4evUqkpOTce3aNQwdOlT8xLqCXC7HyJEj8f3336OoqAh2dnbYunUrbGxs8MADD1Tabn5+/l13BIKDgxETE4NPPvkEY8eOha2tLfLz8yWkU9nHH38Md3d3jB8/Hn/88cdt13nppZfEf8vlcvzf//2feKTlVrd7fbej0+lMdiS9vLzwzDPP4KmnnrrrY7VaLX744Qe8+eabNW6g2rZta/J1mzZtIJfLxfPHU1NTIZfL0aZNG5P13Nzc4OzsjNTUVAAQm8yOHTvW6PmrKy0tDQBue3TM398fcXFxAG42J7eb5rRiLDU1Fa1bt660/NZTh5ydnTF8+HDMnj0b9vb2uHLlCgRBwEcffVTpXPoKWVlZ8PDwEL92dXXFgAEDsGnTJnTv3h2bNm3CQw89BLm88md/aWlp+Pjjj6FWq5Gbm2uy7E5N5q1u3LhR6Wf6di5evIjly5fj0KFDlbb975+hxMTE2zY4t7Nv375qr7tx40Zs3LgRQPmHD0FBQZg7d26l6Z9vFRYWhgkTJmDDhg2IiIgQT28josrYMBBRjc2ePRtDhw4FUH4R4vjx47F06dJKpyu4uLggKioKW7duxZQpU7Bjxw6Ulpbe9igAAAQGBiIwMBC//PILEhMTMWTIEDg6Ot523Yceeghr167Frl27MGLECGzbtk2cH//frl27hoiIiDu+pqeffhpJSUlYtWoVVqxYUY0UqufSpUvYsmULPvjgA/HajNuZM2cOAgMDodfrcerUKXz22WewtLTElClTTNb75JNPTDJJSkq67QWfNjY24ulUhYWF2LRpExYtWgQ3NzcMGzbsjjUvX74c7dq1w+jRo00u7JWiqqMBjeW0j1s/Pa+pBQsWwM/PD6WlpTh8+DC+/PJLAOWn9VR8Cv7ss8+if//+t338v5sqoLypnjNnjnjR9TvvvFPpe2QwGPDMM88gNzcXEydOhL+/P+zt7ZGZmYm5c+dW6xN4oLwR+ncD+G95eXl44okn4OjoiGnTpqFNmzawsbHBmTNnsGTJkkrP5ePjU2nCgh07dtz2FK6goCDMmDHDZGz9+vWVLgoHyo8APfHEExAEASkpKVi5ciUmT55cZYMOlB9BOXLkCIDyJrniwwciqowNAxHVmFKpFP/do0cPPP7449iwYQMeeughBAcHm6w7atQovPjiizh58iS2bt2KLl263PFT47Fjx+Lrr7/G9evXKx1ZuFWnTp3QpUsXbN26FZ6enkhLS7vtBZkZGRkoLCy8642wbG1t8fbbb+Ps2bNwcnLClClTcO7cObz33nt3fNzdLF26FIGBgXfdSe/atat4DcOAAQNw9epVrFmzBi+++KLJJ8hKpdLkRmFVfQJsYWFhMqf/gAED0Lt3b+zdu/eOtZw9exbbt2/HypUrJd1P4/Lly1AoFCZfG41G+Pr6AijfYTQajbh8+TLat28vrnf9+nXk5eXBx8cHwM2d5YsXL951p1WKiiNOSUlJlT7FTkpKEpe3bNkS9vb2SEpKqrSNitNtKmr+tx49eoifcA8cOBAXLlzA3r17AUDMyMrKqkb3XoiMjISNjQ1mzpyJsLAwtGnTplLDcOHCBSQnJ+O9997DQw89JI7v37+/2s9TcXrc8OHD77jekSNHkJOTgxUrVqBnz57i+K0zHt3K3t6+0uuNj4+/7botW7astO6uXbtuu66np6fJuvb29pg1a1aV2wbKj/xdunQJc+bMwZIlS7B06dLb/g4hIl7DQES1YMaMGXBzcxMvHLxVZGQkWrZsiS+++AJ///13lUcXKowYMQKZmZlwdXUVd6CrMmrUKOzfvx/ffPMNWrRoYXIBdIXt27cDwG2vB/i3ZcuWIT09HR988AH69etX5QXK1XX8+HH89ddfmDVrVo0/US8uLobBYKiU5726WxOwdOlShIaGYtCgQZK2v2HDBpOv169fDwDi92bAgAEAgG+++cZkva+++spkeUREBBwcHLB69epK563fOt2sVN26dUOrVq3www8/mEznGhsbi0uXLmHgwIEAyk8P69+/P/766y9otVpxvZycHPzyyy/o1q3bbU9Hup2SkhIx/1atWqFXr1748ccfK13UD+C20xEDEC9CPn/+/G2v76moGTDNSRAErFu3rlp1AhCvS7rb++B2z1VaWmr2qUkrjmzc7nQtADhx4gS+/PJLPPXUU3j22Wfx3HPPYf369eIRByIyxSMMRHTPHB0dMX/+fEyZMgVffvklXnjhBXGZlZUVhg8fjvXr18PCwuKun1i6uLhg3759kMvld93JHjFiBD744AP8+eefmDBhgskpP9evX8fHH3+MjRs3Yvjw4SafZt/OgQMH8PXXX+P999+v8hPjmtq3bx/Cw8Or9QnygQMHkJGRgbKyMpw6dQpbt26FSqWSPMOMwWAQLzQuLCzE5s2bodPpMHjw4LvW/P3330t6TqD8k+XJkyejf//+OH78OH777TeMGDECgYGBAMpPOxs9ejR+/PFH5OXloWfPnjh16hS2bNmCwYMHi42do6MjXnvtNcybNw8PP/wwRowYAWdnZ5w7dw7FxcX3fOTHysoKs2bNwmuvvYYnnngCw4cPF6dV9fHxMbn+YPr06di7dy8ee+wxPPbYY7C2tsZPP/2E/Pz8SvckuNWePXuQmJgonvry999/ixd3A8Abb7yBxx57DCNHjsQjjzwChUKB69ev4/jx48jIyMBvv/122+1Onz4dzz33HFxcXG673N/fH23atMF7772HzMxMODo64o8//kBeXl61stmwYQOWL18OV1dXXLlyxWTSgrKyMmi1Wuzfvx/h4eEICQmBi4sL5s6diyeffBIymQy//vprrTR1NZGWloY9e/aIpyR99tln8PHxQZcuXXD58mWTdUtKSjBnzhy0bdsWM2fOBABMnToVMTExeO2117B161bY29vXa/1EDR0bBiKqFffddx8GDRqEVatWYejQoSanpYwaNQrr169H3759K92v4Xaqe3fh1q1bIzw8HLGxsZWm0rxy5QoOHTqEF1980aSBuZ0bN25gzpw5GD58+F2PgNSETCbDK6+8Uq11K643sLS0hIeHBx5//HFMmzZN8nOXlJTg+eefB1B+eoafnx/ef/998ZPzqgwaNAihoaGSn3f58uX46KOPsHTpUlhaWuKJJ57A7NmzTdZZuHAhfH19sWXLFuzatQutW7fGpEmTKl2vMW7cOLRq1Qqff/45Vq1aBUtLS/j7+5vszN+LMWPGwNbWFmvWrMGSJUtgb2+PwYMH49VXXzV5D7Zv3x4bNmzA0qVL8fnnn0MQBHTv3h3vvPOOyel5/1ZxvwMrKyt4e3vjpZdeEu8FAgAdOnTApk2bsGLFCmzZsgU5OTlwdXVFly5dTC6C/zdra2uT09L+zcrKCp999hkWLlyI1atXw8bGBvfddx8ef/zxak05e+s1Mf/+3gHlN4X77LPPEB4ejpYtW+Kzzz7De++9h+XLl8PZ2RkPPvgg+vbti+eee+6uz1VbYmJiEBMTA5lMhtatWyMkJAQzZsy47TUJy5Ytw5UrV/DDDz+IF/VbW1vj3Xffxfjx4/H+++/fdvpYouZMJtT3xwBE1OycO3cOo0aNqnROdW146aWXcOHCBfz555+1ul2qmU8++QQrVqzAwYMH77gzSw1fQEAA1q1bV+UpgZs3b8aWLVvw7bff1nNlRGQuvIaBiOrcTz/9BHt7ewwZMqRWt3v16tXbHl0gIiKi2sNTkoiozqjVaiQkJOCnn37C448/XmvnBWu1Whw9ehQbN26EpaUlxo8fXyvbJSJg5MiRd7yQu02bNjWa2YmIGj82DERUZxYuXIjr168jMjISU6dOrbXt/v333+JdWd999124ubnV2raJmrslS5bccblSqbzjtRtE1PTwGgYiIiIiIqoSr2EgIiIiIqIqsWEgIiIiIqIqsWEgIiIiIqIq8aLne3Ts2DEIgmByh1kiIiIiooZKr9dDJpMhJCSkWuvzCMM9EgQB5rpuXBAElJaWmu35GyvmJg1zk47ZScPcpGFu0jA3aZibdObMrqb7rzzCcI8qjix079693p9bp9MhPj4eHTp0qLX57ZsD5iYNc5OO2UnD3KRhbtIwN2mYm3TmzO7UqVM1Wp9HGIiIiIiIqEpsGIiIiIiIqEpsGIiIiIiIqEpsGIiIiIiIqEpsGIiIiIiIzMDW1tbcJVQLGwYiIiIionpUXFoGK2tbePn6w8raFsWlZeYu6Y44rSoRERERUT0p1RuwKSYBW/cmorBIDwc7KzzY3x8PqzrC2srC3OXdFhsGIiIiIqJ6UFxahk0xCfhh53lxrLBIj+//+XpMVAfYWje83XOekkREREREVA8s5HJs3Zt422W/7U2Ehbxh7po3zKqIiIiIiJqIyxl5+CU2Adl5xSgs0t92ncIiPXTFt19mbg3vmAcRERERUSOXk1+CPcdSoI7T4lJKLpwdrPFAn3ZwsLO6bdPgYGcFe1srM1R6d2wYiIiIiIhqQanegCNnM6DWaBF37iqMRgEAYGkhQxc/V+QWluDB/v7iNQu3erC/PwxGI6wa4AlAbBiIiIiIiCQSBAHxydlQa7TYdzwVhcU3p0jt1KYFVGEKRAT7wMXRBgDwsKojgPJrFjhLEhERERFRE5WRVYgYjRbqOC0ysnTiuFtLO0SFKRAV5gtfd6dKj7O2ssCYqA4YN6gTCnQlcLS3gcFobLDNAsCGgYiIiIioWgqK9Nh/IhVqjRZnk7LFcTsbC/Tr4Q2VUoFu/q0hl8vuuB1ba0vodDqkaZPg5+cHe3v7ui79nrBhICIiIiKqQpnBiGPnr0Kt0eLwmQzoy4wAALkMCOroBpVSgT7dvGBrU/Pd6uLi4tout040qIbh8uXLWLt2LU6cOIGLFy/C398f27Ztq3L9Xbt24aWXXkLHjh0rrZefn4/Fixdj165d0Ov16N+/P+bNmwd3d/e6fhlERERE1IgJgoDE1Fyo47TYczQVOQUl4rK2nk5QKRUYEOqLVi52Zqyy/jSohuHixYuIjY1FUFAQjEYjBEGoct3i4mIsWrQIrVu3vu3yGTNmICEhAW+++SZsbGywfPlyPP/889i0aRMsLRvUyyYiIiKiBiArtwixR1Og1mhxOSNfHG/haIMBob5QKRXw83aGTHbnU46amga156xSqTB48GAAwNy5c3H69Okq1129ejW8vb3h6+tbab1jx45h3759WLt2LSIiIgAAfn5+GDZsGHbu3Ilhw4bV3YsgIiIiokajuKQMh06nQ63R4sTFa/hnJlRYWcrRp5sXVEoFgju5wdKi4U13Wl8aVMMgr+btsK9cuYKvvvoKP/zwA77++utKy/fs2QNnZ2eEh4eLY/7+/ujcuTP27NnDhoGIiIioGTMaBZxOvA61RosDJ9NQVGIQl3X1b4WoMAXCg7zhaNcwb6RW3xpUw1Bd77zzDkaNGoXAwMDbLk9MTISfn1+lw0X+/v5ITEysjxKJiIiIqIHRZuYjJk6LmLgUXM8pEse9WjkgSlk+FapnKwczVtgwNbqGQa1W49ixY9ixY0eV6+Tl5cHJqfK8ty4uLnc8zUkqQRCg0+nuvmItKyoqMvk/VQ9zk4a5ScfspGFu0jA3aZibNI0ht7zCUhw8nYk9x9OQkJInjjvYWqJvdw9EBnujk8JF/KC5vvbpzJmdIAg1ug6jUTUMJSUlWLRoEaZOnQpXV1dzlyPS6/WIj4832/MnJyeb7bkbM+YmDXOTjtlJw9ykYW7SMDdpGlpuZQYBF9KKcTKpEBfSimEsnwkVMhnQ0dsWQX726ORjBysLGYyF6Th3Lt1stZorO2tr62qv26gahm+++QZyuRzDhw9HXl55h6jX62E0GpGXlwdbW1tYW1vD2dkZGRkZlR6fm5sLFxeXWq/LysoKHTp0qPXt3k1RURGSk5PRrl072Nk1j2m9agNzk4a5ScfspGFu0jA3aZibNA0pN0EQcDElF3uOp+PAqUwUFpWJy/y9nRAZ7I1+3T3h4lj9HeW6ZM7sEhISarR+o2oYEhMTcfnyZfTt27fSsp49e+LNN9/EhAkT4O/vj4MHD1Y63JKUlIROnTrVel0ymcysd+izs7Nr8HcIbIiYmzTMTTpmJw1zk4a5ScPcpDFnbpnZOuyO00Kt0SLteqE43srFFgNDfRGlVKCtp7NZaqsOc2RX02lhG1XD8Pzzz2P06NEmY59//jmSkpKwePFitGvXDgAQGRmJVatW4eDBg+jXrx+A8mbh7NmzmDhxYn2XTURERES1SFesx4GTafhLo8XpS1niuI21Bfp1L58KtXsHN1jIm9f9EupKg2oYioqKEBsbCwBITU1FQUGBeHFzr1690L59e7Rv397kMVu2bEFmZiZ69+4tjoWEhCAiIgKvv/465syZAxsbG3z44YcICAjAkCFD6u8FEREREVGtMBiMOH7xGtQaLQ6dzkCpvnwqVJkM6NGhNVRKBfp294adTYPavW0SGlSiWVlZmD59uslYxdfr1q0zaQruZvny5Vi8eDEWLFiAsrIyREREYN68ebzLMxEREVEjkpSWC7VGi9ijKbiRXyKO+7o7QqVUYGCoAm4ted1JXWpQe8++vr44f/58jR7z7rvv3nbcyckJixYtwqJFi2qjNCIiIiKqJzfyihF7LAVqjRZJaTenQnWyt8aAUB+olAp08G1R43PxSZoG1TAQERERUfNUojfg8Ol0qDVaHLtwDUajAACwtJCjV1cPqMIUCA30gJWl3MyVNj9sGIiIiIjILIxGAWeTsqDWaLH/ZBp0xTenQg1s2xIqpQIRwT5wsm8YU6E2V2wYiIiIiKhepV0rgDpOi5i4FFzNvnlnZXdXe0SF+UIVpoC3m6MZK6RbsWEgIiIiojqXryvFvuOpUGu0OHf5hjhuZ2OJiCBvqJQKdPFrBTmnQm1w2DAQERERUZ3Qlxlx9Fwm1HFaHDmTiTKDEQAglwEhAe5QKRXo1dUTttbcJW3I+N0hIiIiolojCAISUnKg1mix51gq8gpLxWV+3s5QKRUYEOKLls62ZqySaoINAxERERHds2s3irD7qBYxcVpoMwvE8ZZONhgQ6guVUgE/bxczVkhSsWEgIiIiIkmKS8pwPLEQGw/F4UxSNoTymVBhbSlHn+5eUCkVCO7oBgsLToXamLFhICIiIqJqMxgFnEq4BrVGiwMn01CiN4rLurVvBVWYAuFB3rC3tTJjlVSb2DAQERER0V1dyciDWqPF7qMpyMotFsddnSwxuFdbDOnjDw9XezNWSHWFDQMRERER3VZOfgn2HE9BjEaLhJRccdzRzgr9Q3zQr5sbyvLT0KWLP+zt2Sw0VWwYiIiIiEhUqjfg77OZUGu0iDuXCYOx/MIEC7kMys4eUCkV6NnFA1aWFtDpdIiPTzdzxVTX2DAQERERNXOCIOBc8g2o47TYezwVhUV6cVlHRQsMUioQEewDF0cbM1ZJ5sKGgYiIiKiZysgqRExc+SlH6VmF4nhrF1tEKRWIClNA4eFkxgqpIWDDQERERNSMFBbpse9EGmLitDiTmCWO21pboF8Pb6iUCnRv3xpyucyMVVJDwoaBiIiIqIkzGIw4dqF8KtRDp9OhLyufClUmA4I6ukGlVKBvNy/Y2nDXkCrju4KIiIioCRIEAUlp5VOhxh5NQU5BibisjacTBikVGBDqi1YudmaskhoDNgxERERETUhWbhFij6YiJk6L5PQ8cdzF0RoDQn2hClPA38cFMhlPOaLqYcNARERE1MgVl5bh0OkMqP++ghMXr+GfmVBhZSlH766eUCkVCAlwh6WF3LyFUqPUoBqGy5cvY+3atThx4gQuXrwIf39/bNu2zWSd9957D3v27EFaWhpkMhn8/Pzw7LPPYvjw4SbrlZaW4sMPP8Rvv/2GwsJChISEYP78+fD396/Pl0RERERUJ4xGAWcSs6DWaLH/ZCqKSgzisi5+rlApFQgP8oGjnZUZq6SmoEE1DBcvXkRsbCyCgoJgNBohCEKldQoLCzFu3Dj4+/tDJpPhjz/+wMsvvwyj0YiRI0eK6y1cuBDR0dGYO3cuPDw88Nlnn+Hpp5/G9u3b4eTE6cGIiIiocUq5mg+1RovdR1Nw7UaROO7Zyh6qMAUGhing1drBjBVSU9OgGgaVSoXBgwcDAObOnYvTp09XWuett94y+bp///5ISEjAli1bxIYhIyMDGzduxBtvvIGHH34YANC9e3dERUXhhx9+wPPPP1/Hr4SIiIio9uQVlmLvsRSo47S4cCVHHHewtUREsA9USgU6t3PldQlUJxpUwyCXSzuvrkWLFigsvHmzkX379sFoNOKBBx4wWSc8PBx79uxhw0BEREQNnr7MCE18BtQaLTTxmSgzlJ95IZfLEBboDpVSgV5dPGFtZWHmSqmpa1ANQ3UJggCDwQCdTge1Wo39+/fjgw8+EJcnJiaiVatWcHFxMXlc+/btsXHjxvoul4iIiKhaBEHAhSs3oNZosfd4KvJ1enFZe18XqMIUiAzxRQsnGzNWSc1No2wYDh48iGeeeQYAYGlpifnz55scTcjLy7vtdQrOzs7Izc2t9XoEQYBOp6v17d5NUVGRyf+pepibNMxNOmYnDXOThrlJY+7cruUUYe/xdOw5no70rJv7FC2dbNA/yAv9g73QxsPxn1GDWfY7bsfcuTVm5sxOEIQanb7WKBuGHj16YOPGjSgoKMCePXuwcOFCWFhYYNy4cWapR6/XIz4+3izPDQDJyclme+7GjLlJw9ykY3bSMDdpmJs09Zlbsd6I+CtFOJGkQ/LVmzdVs7KQobPCDkF+9vDzsIFcXobCbC3is+uttBrj+006c2VnbW1d7XUbZcPg6OiI7t27AwD69u0Lg8GAd999F2PGjIGFhQWcnZ1RUFBQ6XF5eXmVTlOqDVZWVujQoUOtb/duioqKkJycjHbt2sHOjndprC7mJg1zk47ZScPcpGFu0tRXbkajgJOXsrDneDr+jr+KUr0RACCTAV39XBEZ7IVeXdxhZ9M4dtH4fpPOnNklJCTUaP3G8W68i65du+Kbb75BdnY23Nzc4O/vj+vXryM3N9ekQUhMTKyT+zDIZDLY29vX+nary87OzqzP31gxN2mYm3TMThrmJg1zk6aucktOz4Nao0XsUS2y824eTfBxc8SgngoMCPWFe8vG+/3i+006c2RX09m0mkTDEBcXB0dHR7Rs2RIAEBERAblcjp07d4qnKeXm5mLfvn148cUXzVkqERERNRM38osRezQVMRotEtNuXkPpZG+NASE+iFIq0FHRglOhUoPXoBqGoqIixMbGAgBSU1NRUFCAHTt2AAB69eqFq1evYsmSJXjggQfg4+MDnU6H3bt34+eff8bLL78MS8vyl+Pp6YmHH34Y77//PuRyOTw8PLB69Wo4OTnh0UcfNdvrIyIioqatRG/AkdMZUMdpcfT8VRiN5VOhWlrI0LOLJ1RKBcICPWBlKW0qeSJzaFANQ1ZWFqZPn24yVvH1unXr0L59ezg7O2PVqlW4du0anJyc4O/vjxUrVog3fKswb948ODg4YOnSpSgsLERoaCi++uor3uWZiIiIapXRKCA+ORtqjRb7TqRCV1wmLgto2xIqpQIRQT5wdqj+RaZEDUmDahh8fX1x/vz5O66zbNmyam3L2toac+bMwZw5c2qjNCIiIiITadcLEKNJQUycFpnZN6c5dW9ph6gwBaKUCvi4Od5hC0SNQ4NqGIiIiIgasgJdKfaeSEOMRov45JvznNrZWCIiyBtRSgW6+rWCXM7rEqjpYMNAREREdAdlBiOOnrsKtUaLw2cyUGYonwpVLgOCA9yhClOgdzdP2Fpzt4qaJr6ziYiIiP5FEARcSsmFOk6L2KMpyCssFZe183KGSlk+Faqrs60ZqySqH2wYiIiIiP6RlVuM6EOpUGu00Gbmi+MtnGwwMNQXKqUCft61fxNYooaMDQMRERE1a0UlZdhzPA2/77+GpMwUCOUzocLaUo4+3bwQpVQgpJMbLCw4FSo1T2wYiIiIqNkxGAWcTrgOdZwWB06mobjUIC7r6t8KKqUC4T284WBnZcYqiRoGNgxERETUbFzJyENMXAp2x2lxPbdYHPd0tUNnHyuMua8H2vm0MmOFRA0PGwYiIiJq0nILSrDnWCrUcVokaHPEcQc7K0QG+0ClVEDhZoNz587BvaWd+QolaqDYMBAREVGToy8z4MjZTMRotNDEZ8JgLL8wwUIug7KzB6KUCvTq4gErSwsAgE6nu9PmiJo1NgxERETUJAiCgPOXb0Ct0WLP8VQUFunFZR0ULaAKUyAyxAcujjZmrJKo8WHDQERERI1aRlYhdh9NgVqjRfr1QnG8tYstBoYpEBXmizaezmaskKhxY8NAREREjU5hkR77TqQhJk6LM4lZ4rittQX69fCGSqlAt/atYSGXmbFKoqaBDQMRERE1CgaDEccuXINao8Xh0+koLTMCAGQyIKijG1RKBfp284KtDXdviGoTf6KIiIioQUtMzYVao0XssRTk5JeI4woPJ6iUCgwM9UXrFpzdiKiusGEgIiKiBic7rxix/1yXkJyeJ467OFpjQIgvosIUaO/rApmMpxwR1TU2DERERNQgFJeW4dDpDMRotDh+4Sr+mQkVlhZy9O7mCZVSgdAAd1hayM1bKFEzw4aBiIiIzMZoFHAmMQtqjRb7T6ahqKRMXNa5nStUSgUigrzhaG9txiqJmrdaaxiys7Mhk8nQsmXL2tokERERNVEpV/MRE5eCmDgtrt0oEsc9XO3Lr0sI84V3a0czVkhEFardMBw8eBCdOnVCq1atTMa/+uorfPHFF8jOzgYAtG7dGpMnT8bjjz9eu5USERFRo5ZXWIq9x1MRo9Hi/JUb4ri9rSX6B/sgKkyBLn6uvC6BqIGpdsPw7LPP4v3338fIkSPFsa1bt+K9995Dq1atoFKpYDAYcOzYMSxcuBBOTk548MEH66RoIiIiahz0ZUZo4jMRE6fF32czUGYovzBBLpchNMAdKqUCvbp6wsbKwsyVElFVqt0wCIJQaWzNmjXo3r07vv76azg4OAAAcnJyMH78eKxfv77GDcPly5exdu1anDhxAhcvXoS/vz+2bdsmLi8oKMBXX32F2NhYJCcnw9raGj169MDMmTMREBBgsq38/HwsXrwYu3btgl6vR//+/TFv3jy4u7vXqCYiIiKqGUEQcFGbA7VGiz3HUpGvKxWX+fu4QKVUIDLEBy2dbM1YJRFVl+RrGARBQFJSEt5++22xWQCAFi1aYOzYsfj0009rvM2LFy8iNjYWQUFBMBqNlZqUtLQ0/Pjjjxg7dixmzJiBkpISfPnllxg/fjw2bdqE9u3bi+vOmDEDCQkJePPNN2FjY4Ply5fj+eefx6ZNm2BpyWu9iYiIatvVGzrsjiufCjX1WoE47upsg4GhCkQpFWjn5WzGColICsl7zrm5udDr9fDw8Ki0zMPDA8XFxTXepkqlwuDBgwEAc+fOxenTp02W+/r64s8//4Sd3c2bs/Tp0wcqlQrfffcd5s+fDwA4duwY9u3bh7Vr1yIiIgIA4Ofnh2HDhmHnzp0YNmxYjWsjIiKiynTFehw4mY6YOC1OJlwXx62tLNCvuxeilAoEdXSDhZzXJRA1Vvd0hKEqUi9WksvvPK+yvb19pTEHBwe0adMGV69eFcf27NkDZ2dnhIeHi2P+/v7o3Lkz9uzZw4aBiIjoHhiMAk5cvIYYjRYHTqWjVG8Ql/Xo0BpRYQr06+EFe1srM1ZJRLWlRg1DUVERcnJyAJQfYQCAwsJCcayCTqerleKqIy8vDxcvXkS/fv3EscTERPj5+VVqXPz9/ZGYmFhvtRERETUll9PzoNZosftoCrLzbp5J4OPmWD4Vaqgv3F0rf7hHRI1bjRqGN954A2+88YbJ2NSpUyutJwhCvU2J9sEHH0Amk2HChAniWF5eHpycnCqt6+LiUuk0p9ogCEK9NkkVioqKTP5P1cPcpGFu0jE7aZibNLWdW05BCfafzMCe4+lITs8Xxx3trBDewxORwV5o7+Ms/t03x9/D2sD3mzTMTTpzZlfTffVqNwxTpkyRVFBd2rRpE3766Se8++678PT0NFsder0e8fHxZnv+5ORksz13Y8bcpGFu0jE7aZibNPeSm94g4HxKEU4k6ZCQXoyKs5DlcqCTty2C/BzQ0dsWlhYC9PlpOHcurXaKbgD4fpOGuUlnruysrat/9/RG2zDExsZiwYIFePHFFzF69GiTZc7OzsjIyKj0mNzcXLi4uNR6LVZWVujQoUOtb/duioqKkJycjHbt2plcCE53xtykYW7SMTtpmJs0UnMTBAHnr+Rgz/F0HDydCV1xmbisg68LIoO90K+7B5zsq7+T0Zjw/SYNc5POnNklJCTUaP1GOb/o8ePHMX36dDz00EOYPn16peX+/v44ePBgpcMtSUlJ6NSpU63XI5PJbntBdn2xs7Mz6/M3VsxNGuYmHbOThrlJU93c0q8XIiZOi5g4LTKybp5O5NbSDlFhCkSF+cLXvfJpvk0V32/SMDfpzJFdTS8dqHbDcObMmRoX07Vr1xo/5m4SEhIwadIk9OnTB//73/9uu05kZCRWrVqFgwcPihdDJyUl4ezZs5g4cWKt10RERNSYFOhKse9EGtQaLeKTs8VxOxsLhPfwgUqpQFf/VpBzKlQiQg0ahrFjx1a7G6n4ZL+m5/UXFRUhNjYWAJCamoqCggLs2LEDANCrVy8IgoDnnnsONjY2eOqpp0wuYHZ0dBRPCwoJCUFERARef/11zJkzBzY2Nvjwww8REBCAIUOG1KgmIiKipqDMYMTR81eh1mhx5EwG9GVGAIBcBgR3ckeUUoE+3Txha90oTz4gojpUo98KNjY2GDBgACIiIurkbslZWVmVTjGq+HrdunUAIF6b8PTTT5us16tXL3z77bfi18uXL8fixYuxYMEClJWVISIiAvPmzeNdnomIqNkQBAGXUnMRo9Ei9lgKcgtKxWVtPZ2gUrbBgFAftHLhuedEVLVq7z2/9dZb2Lp1K/78808cOXIE999/P0aMGAGlUllrxfj6+uL8+fN3XOduyys4OTlh0aJFWLRoUW2URkRE1Gjk6Qz4dW8y9p3MwJWMm1OhtnC0wYBQX6iUCvh5O9fbFOhE1LhVu2F45JFH8MgjjyAzMxNbt27F9u3b8cMPP8Db2xvDhw/H8OHDERgYWJe1EhERURWKS8pw8HQ6dh1OxslLN69LsLKUo083L6iUCoR0coOFhdyMVRJRY1Tj83M8PDwwceJETJw4EZcuXcJvv/2G7du344svvkCHDh0we/Zs9O/fvy5qJSIiolsYjQJOXboOtUaLAyfTUFxqEJcFtm2Bwb3aITzIG452Vmaskogau3s6ob99+/aYOXMmhg4dikWLFuHIkSM4ceIEGwYiIqI6pM3M/2cq1BRcz7l5l1ivVg6ICPKAl6MO4T27c5pLIqoVkhsGrVaL7du3Y/v27UhISIBCocD//d//YcyYMbVZHxEREQHILSjB3uOp+EujRYI2Rxx3sLNC/2AfqMIUCGzXEkVFRTWepZCI6E5q1DBkZWUhOjoa27Ztw4kTJ9C6dWsMHToU77zzDnr06FFXNRIRETVL+jID/j6bCbVGC018JgxGAQBgIZchLNADKqUCPbt4wNrKwsyVElFTVu2G4dlnn8Xhw4dhb2+P++67D9OnT0efPn0gl/PiKSIiotoiCALOX74BtUaLvcdTUVCkF5d1ULRAVJgvIoN90cLJxoxVElFzUu2G4cCBA7C1tUX37t2RnZ2NdevWifdGuB2ZTIZPP/20VookIiJq6jKzdYiJ00Kt0SL9eqE43srFFlFhCkSF+aKNp7MZKySi5qraDYO3tzcAIDk5uVrrc25nIiKiOyss0mP/yTSoNVqcScwSx22tLdCvhzdUYQp069AaFnL+TSUi86l2w6BWq+uyDiIiombBYDDi2IVriNFoceh0OkrLjAAAmQzo0aE1VEoF+nb3hp3NPU1kSERUa/jbiIiIqB4kpeVCrdFi99EU5OSXiOMKD0eolG0wMNQXrVvYmbFCIqLbY8NARERUR7LzihF7NAVqjRbJ6XniuLODNQaE+kIVpkB7XxeexktEDRobBiIiolpUXFqGw6czoI7T4vj5q/hnJlRYWsjRu6snVEoFQgPdYWnBWQaJqHFgw0BERHSPjEYBZ5KyEKPRYt+JNBSVlInLOrdzRZRSgf5B3nC0tzZjlURE0rBhICIikij1WgFiNFrExGlx9UaROO7uag/VP1Ohers5mrFCIqJ7x4aBiIioBvJ1pdh7PBVqjRbnL98Qx+1tLRER5AOVUoHO7Vwh51SoRNREsGEgIiK6C32ZEXHnMqHWaPH32UyUGcqnQpXLZQgNcIcqTIFe3TxhY2Vh5kqJiGpfnTQMr732Gtzd3fHUU0/B1dW1Lp6CiIioTgmCgIvaHMRotIg9lop8Xam4zN/bBVFKBQaE+KCls60ZqyQiqnt10jBs2bIFAPDtt9/iP//5D2bMmFEXT0NERFTrrt0owu6jWqg1WqRcLRDHWzrZYOA/1yX4ebuYsUIiovpVJw3DX3/9BZ1OhyNHjuDIkSN18RRERES1Rlesx8FT6VBrtDh16TqEf6ZCtbayQN9uXlApFQjq2BoWnAqViJqhOmkYfHx8AAAdO3bE448/Xu3HXb58GWvXrsWJEydw8eJF+Pv7Y9u2bSbrREdH4/fff8eJEyeQmZmJ2bNn47nnnqu0rfz8fCxevBi7du2CXq9H//79MW/ePLi7u9/biyMioibBYBRw8uI1qOO0OHgqHSWlBnFZ9/atoVL6ol8Pb9jbWpmxSiIi82tQFz1fvHgRsbGxCAoKgtFohFDxEc8tduzYAa1Wi4EDB+LHH3+sclszZsxAQkIC3nzzTdjY2GD58uV4/vnnsWnTJlhaNqiXTURE9ehyRt4/U6GmIDuvWBz3cXNAlFKBqFAF3F3tzVghEVHDImnPeefOndVab8iQITXarkqlwuDBgwEAc+fOxenTpyuts3z5csjl5YeEq2oYjh07hn379mHt2rWIiIgAAPj5+WHYsGHYuXMnhg0bVqO6iIioccvJL8GeYylQx2lxKSVXHHe0s0JkSPlUqJ3atIRMxqlQiYj+TVLDMG3aNPGX6u2OAgCATCZDfHx8jbZb0Qjc6zp79uyBs7MzwsPDxTF/f3907twZe/bsYcNARNQMlOoNOHI2A2qNFnHnrsJoLP97ZWkhg7KzB1RKBZSdPWBlyalQiYjuRFLDIJPJYG1tjSFDhmDYsGFwcHCo7bruSWJiIvz8/Cp9UuTv74/ExEQzVUVERHVNEATEJ2dDrdFi3/FUFBaXics6tWkBVZgCEcE+cHG0MWOVRESNi6SGYffu3diyZQu2bNmCXbt2YciQIRg7dix69epV2/VJkpeXBycnp0rjLi4utz3N6V4JggCdTlfr272boqIik/9T9TA3aZibdMxOmprklpmtw57j6dh7PB2ZN26u38rFFpFBXugf7AUft4oPtwxm+Z1dX/h+k4a5ScPcpDNndoIg1OgUTEkNg4eHByZPnozJkydDo9Fg06ZNmDRpElq1aoUxY8Zg0qRJsLBoPod49Xp9jU+/qk3Jyclme+7GjLlJw9ykY3bSVJVbUakRZ6/ocCJJhyvXbt5UzdpShi5t7BDkZ4+27jaQy/TIu34FedfrqeAGgu83aZibNMxNOnNlZ21tXe1173m6IKVSCaVSiRdeeAEzZszAJ598gsceewwtWrS4101L5uzsjIyMjErjubm5cHGp/ZvtWFlZoUOHDrW+3bspKipCcnIy2rVrBzs7u3p//saKuUnD3KRjdtLcLrcygxEnE7Kw53g6NOeuQV9mBADIZED39q0QGeyFnp3dYWvdfD60+je+36RhbtIwN+nMmV1CQkKN1r+nhqGsrAxqtRqbNm3C/v37ERgYiAULFsDZ2fleNnvP/P39cfDgwUqHW5KSktCpU6dafz6ZTAZ7e/NNwWdnZ2fW52+smJs0zE06ZieNra0t0rNLoY7TYs/RVOQUlIjL2ng6YZBSgQGhvmjlwp2VW/H9Jg1zk4a5SWeO7Go6I5ykhuHcuXPYvHkztm7dCplMhpEjR+KVV16pk51xKSIjI7Fq1SocPHgQ/fr1A1DeLJw9exYTJ040c3VERFQd2XnF2H82H2t3HYL2aoE43sLRBpGhPlCFKeDv48KpUImI6pikhuGhhx6Cra0tBg8eDJVKBUtLSyQnJ1c6B6um92EoKipCbGwsACA1NRUFBQXYsWMHAKBXr15wdXVFQkKCyWGUCxcuYMeOHbCzs8OAAQMAACEhIYiIiMDrr7+OOXPmwMbGBh9++CECAgJqXBMREdWf4pIyHDydjhiNFscvXkPFzN1WlnL07uoJlVKBkAB3WFrcfYptIiKqHZJPSSouLsa2bduwfft2AJXvxyDlPgxZWVmYPn26yVjF1+vWrUPv3r3x+++/Y8WKFeLyX375Bb/88gt8fHygVqvF8eXLl2Px4sVYsGABysrKEBERgXnz5vEuz0REDYzRKODUpetQa7Q4eCoNRSUGcVkbN2s80K89onr6wdHOyoxVEhE1X5L2ntetW1fbdQAAfH19cf78+TuuM3XqVEydOvWu23JycsKiRYuwaNGi2iqPiIhqkTYzHzFxWsTEpeB6zs1pBT1b2UMVpkDvrq1xI/MyOnf2hT2bBSIis5HUMDSU+y0QEVHjkltQgr3HU6HWaHFRmyOOO9haIiLYByqlAp3buUImk0Gn0+FGpvlqJSKicvd0fk5paSnOnDmDrKwshIaGwtXVtbbqIiKiJkJfZsDfZzOh1mihic+EwVh+CqtcLkNYoDtUSgV6dfGEtVXznQqViKghk9wwrFu3DitWrEB+fj4A4Msvv0Tfvn2RnZ2NoUOH4tVXX8XDDz9ca4USEVHjIQgCzl+5AbVGi73HUlFQpBeXdfB1QZRSgchgX7RwsjFjlUREVB13bRgKCgowa9YszJw5EwEBAQCATZs2YdGiRRg+fDjCw8Px+uuvi+u7urqiT58+iI6OZsNARNTMZGbrsDtOC7VGi7TrheK4q7MtosJ8EaVUoK2nee/VQ0RENXPXhsFoNOLChQvQ6XTi2FdffYVBgwZh6dKluHHjRqXHdO3aFd9++23tVkpERA2SrliP/SfSoI7T4vSlLHHcxtoC/bp7ISpMgR4d3WAh5/0SiIgao7s2DM7OzibTlQLA5cuX8eSTT1b5mBYtWiAnJ+eeiyMioobJYDDi+MVrUGu0OHQqHaVlRgCATAb06NAaKqUCfbt7w86GU1kTETV2d/1NXlJSgu+++w5Dhw6Fp6cngPIm4nZHFiokJCTAzc2t9qokIqIGISktF2qNFrFHU3Ajv0Qc93V3hEqpwMBQBdxa2pmxQiIiqm13bRh0Oh3ee+89BAYGig1DZGQkfvrpJzz22GOV1r948SJ+/vlnjB07tvarJSKiencjrxixx1Kg1miRlJYnjjvZW2NAaPlUqB18W0Am4ylHRERN0V0bhhYtWuCvv/4yOWIwY8YMPPLIIxgxYgSioqIgk8nwyy+/YNOmTdi5cyfc3Nzw4osv1mnhRERUd0r0Bhw+nQ61Rotj56/in5lQYWkhR6+uHlCFKRAa6AErS7l5CyUiojp314ZBJpPBx8fHZMzDwwObN2/GsmXL8Pvvv0MQBPz6669wcHDA8OHDMWvWLN6TgYiokTEaBZxNyoJao8X+k2nQFZeJywLbtoRKqUBEsA+c7K3NWCUREdU3yVejtWrVCu+88w7eeecdZGdnw2g0wtXVFXI5P20iImpM0q4VQB2nRUxcCq5m35wRz72lHaKUCqjCFPB2czRjhUREZE61Mn1FxdEEo9EIQRB4HisRUQOXryvFvuOpUGu0OHf55iQWdjaWiAjyhkqpQBe/VpBzKlQiomavVhqGrKwsvP766zh48CDkcjmioqLw9ttvw9GRn0gRETUU+jIjjp7LhDpOiyNnMlFmKJ8KVS4DQgLcoVIq0KurJ2ytORUqERHdVCt/FRYtWoQDBw5g9OjRKCkpwdatW+Hu7o7XXnutNjZPREQSCYKAhJQcqDVa7DmWirzCUnGZn7czVEoFIkN84epsa8YqiYioIauVhiEmJgYvvfQSJk+eDABwdHTErl272DAQEZnJtRtF2H1Ui5g4LbSZBeJ4SycbDAj1hUqpgJ+3ixkrJCKixuKeG4b8/HzodDp07dpVHOvWrRt+/PHHe900ERHVQFFJGQ6eSoNao8XJhOsQ/pkK1dpSjj7dvaBSKhDc0Q0WFpycgoiIqu+eG4aysvJp9ywtb27KwsICBoPhXjdNRER3YTAKOJVwDWqNFgdOpaOk9Obv3m7tW0EVpkB4kDfsba3MWCURETVmkhqGnTt3iv8uLCyETCZDXFwc8vPzAQCnTp2qneqIiOi2LmfkIUajxe6jKcjKLRbHvVs7QKVUYGCYAh6u9maskIiImgpJDcO0adMgk8kgVBzvBrBixQqTdTi1KhFR7crJL8Ge4ymI0WiRkJIrjjvaWaF/iA9USgUC2rTk718iIqpVkk9JmjRpEvr161ebteDy5ctYu3YtTpw4gYsXL8Lf3x/btm2rtN7PP/+ML774AmlpafDz88PMmTMRFRVlsk5+fj4WL16MXbt2Qa/Xo3///pg3bx7c3d1rtWYiorpUqjfg77OZUGu0iDuXCYOx/IMaC7kMys4eUCkV6NnFA1aWFmaulIiImirJDUP79u3Rq1ev2qwFFy9eRGxsLIKCgsSbwP3b9u3bMX/+fEyePBl9+vRBdHQ0pkyZgg0bNiA4OFhcb8aMGUhISMCbb74JGxsbLF++HM8//zw2bdpkcr0FEVFDIwgC4pOzEROXgr3HU1FYpBeXdVS0gEqpQP9gH7g42pixSiIiai4a1J6zSqXC4MGDAQBz587F6dOnK63z8ccfY/jw4ZgxYwYAoE+fPrhw4QJWrlyJNWvWAACOHTuGffv2Ye3atYiIiAAA+Pn5YdiwYdi5cyeGDRtWPy+IiKgGMrIKERNXfspRelahON7axRZRSgWiwhRQeDiZsUIiImqOJDUMv/zyC7y9vWu7Fsjld57qT6vVIjk5Ga+++qrJ+LBhw/D++++jtLQU1tbW2LNnD5ydnREeHi6u4+/vj86dO2PPnj1sGIiowSgs0mPfiTTExGlxJjFLHLe1tkC/Ht5QKRXo3r415HJel0BEROYhqWEIDAwEABgMBpw5cwapqakAAB8fH3Tr1u2uO/5SJSYmAig/WnCr9u3bQ6/XQ6vVon379khMTISfn1+lC//8/f3FbRARmUuZwYhj569CrdHi8JkM6MuMAACZDAjq6AaVUoG+3bxga9OgDgITEVEzdde/Rnl5eVi7di0ee+wxeHh4iOPR0dFYvHgxrl+/Ll5rIJPJ0Lp1a7z22mt18il+bm75rCDOzs4m4xVfVyzPy8uDk1Plw/YuLi63Pc3pXgmCAJ1OV+vbvZuioiKT/1P1MDdpmJt0RUVFEAQB55Ku4XB8NvafzEBuYam43NfNAZEh3ugf5AlXZ1sAgNFQCp2utKpNNgt8z0nD3KRhbtIwN+nMmZ0gCDWaUe+uDYNOp8Pnn3+Ovn37ig3Drl278Morr8Df3x+TJ0+Gv78/gPIjAN9//z1mzZoFOzu7SjMXNVV6vR7x8fFme/7k5GSzPXdjxtykYW41k6cz4FSyDieSCnE1N1Uct7eRo3s7ewT52cOrpRVksiJkpiYhM/UOG2um+J6ThrlJw9ykYW7SmSs7a2vraq9714bBxcUFgiCYzFj02WefoWvXrtiwYQNsbG7O0tG3b1+MGzcOEyZMwKefflrrDYOLiwuA8ilT3dzcxPG8vDyT5c7OzsjIyKj0+NzcXHGd2mRlZYUOHTrU+nbvpqioCMnJyWjXrh3s7Ozq/fkbK+YmDXOrvpJSA/6Ov4rY4+k4dSkLFb8+LS1kUAa6IzLEC0EdWsHSom5O32wq+J6ThrlJw9ykYW7SmTO7hISEGq1/14bBzs4O9vb2uHHjhjh28eJFvPLKKybNQgVra2uMGjUKy5Ytq1Eh1XHrkYyKf1d8bWVlBYVCIa538ODBSodbkpKS0KlTp1qvSyaTwd7efHdUrfgeUc0wN2mY2+0ZjQJOJ16HWqPFgZNpKCoxiMsC2rRAR09g9OBguLeq/Q8tmjq+56RhbtIwN2mYm3TmyK6mN/is1hV1PXr0QHR0tHhdgq2trUkD8W83btyo0WGO6lIoFGjXrh127NghTr8KlF9P0bdvX/E5IyMjsWrVKhw8eFC8uVxSUhLOnj2LiRMn1npdRNR8pVzNh1qjxe6jKbh24+Z5qB6u9lD9MxWqi70M8fHxcLSzMmOlRERE0lSrYRg/fjxmzpyJL774AhMnTkR4eDjWrVuH8PBwKJVKk3WPHz+Ob7/9Vrz/QU0UFRUhNjYWAJCamoqCggLs2LEDANCrVy+4urpi6tSpmDVrFtq0aYPevXsjOjoaJ0+exPr168XthISEICIiAq+//jrmzJkDGxsbfPjhhwgICMCQIUNqXBcR0a3yCkux91gK1HFaXLiSI4472FoiItgHUWEKdPFzFT/BMcekCERERLWlWg3D0KFDcebMGSxZsgRqtRodO3ZEYWEhnnzySXTv3l08PSgpKQknT55E69atMWvWrBoXk5WVhenTp5uMVXy9bt069O7dGyNGjEBRURHWrFmDzz//HH5+flixYgVCQkJMHrd8+XIsXrwYCxYsQFlZGSIiIjBv3jze5ZmIJNGXGaCJz4Rao4UmPhNlhvILE+RyGcIC3aFSKtCriyesrSzMXCkREVHtqvbe86xZsxAZGYkvv/wSO3fuhEwmgyAIOHnyJE6ePAlbW1v4+vrimWeewcSJE+Hq6lrjYnx9fXH+/Pm7rjdu3DiMGzfujus4OTlh0aJFWLRoUY3rICICyqedu3DlBtQaLfYeT0W+Ti8u8/dxgUqpQGSID1o62ZqxSiIiorpVo4/be/XqhV69etVVLUREDcLVbB1ijmoRo9Ei9VqhOO7qbIuoMF9EhSnQ1sv5DlsgIiJqOu7p/BydToeCggI4ODjAwcGhtmoiIqp3umI9DpxMg1qTglOXrovjNtYW6NvdC6owBXp0dIOFvGYzSxARETV2NW4YUlJS8MUXXyA2NtbkXgceHh6IiorCs88+K05vSkTUkBmMAk5cuAa1RouDp9NRqi+fClUmA7q3bw2VUoG+3b1gb8vZjYiIqPmqUcOwa9cuzJ49GzqdDj4+PoiKioKDgwMKCwtx/vx5fP/99/jll1/wwQcfmEx7SkTUkCSn50Gt0SL2qBbZeSXiuI+bIwb1VGBAqC/cW3I+cSIiIqAGDUNCQgJmzpwJhUKBt956q9J0qgCg0Wjwxhtv4OWXX8bmzZvNcvdjIqLbuZFfjNijqYjRaJGYliuOO9lbY0CID6KUCnRUtKjxzWyIiIiaumo3DJ999hlatmyJ7777Di1atLjtOkqlEhs2bMCDDz6I1atX44MPPqitOomIaqxEb8CR0xlQx2lx9PxVGI3lU6FaWsjQs4snVEoFwgI9YGUpN3OlREREDVe1G4bDhw9j3LhxVTYLFVq0aIGxY8di48aN91obEVGNGY0C4pOzodZose9EKnTFZeKygLYtoVIqEBHkA2eH2r8bPRERUVNU7YYhJycHPj4+1VrX19cXOTk5UmsiIqqxtOsFiNGkICZOi8zsm3dWdm9ph6gwBaKUCvi4OZqxQiIiosap2g1Dy5YtkZKSUq11U1JS0LJlS8lFERFVR4GuFHtPpCFGo0V8crY4bmdjiYggb0QpFejq1wpyToVKREQkWbUbhl69emHjxo146qmn7nhaUk5ODjZu3IjevXvXRn1ERCbKDEYcPXcVao0Wh89koMxgBADIZUBwgDtUYQr07uYJW+t7us0MERER/aPaf1EnT56MP/74A0888QTeeusthIaGVlrn6NGjeOONN5CTk4NJkybVaqFE1HwJgoBLKblQx2kRezQFeYWl4rJ2Xs5QKcunQnV1tjVjlURERE1TtRuGDh06YOnSpZgzZw4ef/xx+Pj4IDAw0OQ+DCkpKbCxscEHH3yAjh071mXdRNQMXM8pwu6jKVBrtNBm5ovjLZxsMDDUFyqlAn7eLmaskIiIqOmr0TH7IUOGoHPnzlizZg12796NXbt2icvc3Nwwbtw4PPfcc2jbtm2tF0pEzUNRSRkOnkpHjEaLEwnXIJTPhAprSzn6dPNClFKBkE5usLDgVKhERET1ocYn+VbcuA0ACgoKUFhYCAcHBzg6cvYRIpLGYBRwOuE61HFaHDiZhuJSg7isq38rqJQKhPfwhoOdlRmrJCIiap7u6apAR0dHNgpEJNmVjDzExKVgd5wW13OLxXGv1g5QKRUYGOoLz1YOZqyQiIiIOI0IEdWr3IIS7DmWCnWcFgnaHHHcwc4KkcE+UCkVCGjbEjIZp0IlIiJqCNgwEFGd05cZcORMJtQaLeLOZcJgLL8wwUIug7KzB6KUCvTq4gErSwszV0pERET/xoaBiOqEIAg4f/kG1Bot9hxPRWGRXlzWQdECqjAFIkN84OJoY8YqiYiI6G7YMBBRrcrIKkRMXApi4rRIv14ojrd2scXAMAWiwnzRxtPZjBUSERFRTbBhIKJ7Vlikx74TaYiJ0+JMYpY4bmttgX49vKEKU6Bbh9awkPO6BCIiosamUTYMMTEx+Pjjj3Hx4kW0atUKY8eOxUsvvQQLC9Pzn9VqNZYvX46kpCR4e3vjhRdewNixY81UNVHTYjAYcezCNag1Whw+nY7SMiMAQCYDgjq4IUqpQN/uXrCzaZS/ZoiIiOgfje4v+fHjx/Hiiy9i+PDhePnll5GQkIDly5ejqKgIc+bMEdfTaDSYMmUKHn74Ybz++us4dOgQ/vvf/8LBwQEPPPCAGV8BUeMlCAKS0/Nx4HQiYo+lICe/RFym8HASp0Jt3cLOjFUSERFRbWp0DcMnn3yCzp07Y8mSJQCA/v37QxAELFu2DM899xxat24NAPj000/Ro0cP8SZzffr0gVarxccff8yGgaiGsnKLsOtwMnYevoqrOaniuLODNQaE+kIVpkB7XxdOhUpERNQENbqGIT4+vtJpRREREXjvvfewb98+PPTQQygtLcXhw4cxa9Ysk/WGDRuGbdu2ISUlBb6+vvVZNlGjU1xahkOnMxCj0eL4hav4ZyZUWFrI0LurF1RKBUID3WFpITdvoURERFSnGl3DUFJSAmtra5Oxiq8vXboEALhy5Qr0ej38/f1N1mvfvj0AIDExkQ0D0W0YjQLOJGZBrdFi/8k0FJWUics6tXFBJw8ZRt8XDPdWLmaskoiIiOpTo2sY2rZti5MnT5qMHT9+HACQm5tr8n9nZ9OpGyu+rlheWwRBgE6nq9VtVkdRUZHJ/6l6mFtladcKsedEOvYeT8f13GJx3L2lHSKDvdA/yAsu9jIkJyfDAmVmeb83ZnzPScPcpGFu0jA3aZibdObMThCEGp1G3Ogahsceewz//e9/8c0332DUqFHiRc//niGpPun1esTHx5vt+ZOTk8323I1Zc89NV2LA6ctFOJGkQ2pWqThuYyVD1zb2CPKzRxs3a8hkpbhx9TJu/LO8ued2L5idNMxNGuYmDXOThrlJZ67s/n3Gzp00uoZhzJgxuHDhAt5//30sWrQIVlZWmDJlCr755hu4u7sDAFxcyk+XyM/PN3lsXl6eyfLaYmVlhQ4dOtTqNqujqKgIycnJaNeuHezsOCtNdTXn3MrKjDh24Tpij6fj6IVrMBjKL0yQy2UI6tAKkcFeUAa6wdqqcgPenHO7V8xOGuYmDXOThrlJw9ykM2d2CQkJNVq/0TUMcrkcr7/+OqZOnYrU1FR4e3ujrKwMH374IYKCggAAbdq0gZWVFRITE9G/f3/xsYmJiQBQ6dqGeyWTyWBvb1+r26wJOzs7sz5/Y9VcchMEARe1OVBrtNhzLBX5uptHE/x9XBAVpsCAEB+0dLat1vaaS251gdlJw9ykYW7SMDdpmJt05siuprMaNrqGoYKTkxMCAwMBAB999BF8fX3Rr18/AOWHWHr37o0//vgDTz31lPiY6OhotG/fnhc8U7Nw9YYOu+NSoNZokXqtQBx3dbbBwFAFopQKtPNyvsMWiIiIiBphw3Dy5EkcOXIEnTt3RnFxMdRqNX799VesWbPG5DqG//u//8N//vMfvPnmmxg6dCgOHz6Mbdu24cMPPzRj9UR1S1esx4GT6YiJ0+JkwnVx3NrKAv26eyFKqUBQRzdYyHm/BCIiIqqeRtcwWFlZYefOnVi5ciUAICgoCN9++y1CQkJM1lMqlfjkk0+wfPlybNy4Ed7e3li4cCGGDh1qjrKJ6ozBKODExWuI0Whx4FQ6SvUGcVmPDq0RFaZAvx5esLe1MmOVRERE1Fg1uoahc+fO+Omnn6q17qBBgzBo0KA6rojIPC6n50Gt0WL3US2y80rEcR83B6iUbTAw1BfurjyflIiIiO5No2sYiJqzG/nF2HMsFWqNFompN+8n4mRvhcgQX6iUCnRUtKjxxUxEREREVWHDQNTAleoNOHwmA2qNFkfPX4XRWD4VqqWFDD27eCIqTAFlZw9YWcrNXCkRERE1RWwYiBogQRBwNikbMXFa7DueisLiMnFZQJuWiFIq0D/YB84O1b/pChEREZEUbBiIGpD064WIidNCrdEiM1snjru1tENUmAJRYb7wdXcyY4VERETU3LBhIDKzAl0p9p1Ig1qjRXxytjhuZ2OB8B4+UCkV6OrfCnJOhUpERERmwIaByAzKDEYcPX8Vao0WR85kQF9mBADIZUBwJ3dEKRXo080Tttb8ESUiIiLz4t4IUT0RBAGXUnMRo9Ei9lgKcgtKxWVtPZ2gUrbBgFAftHKxM2OVRERERKbYMBDVsazcIuyOS4E6TosrGfnieAtHGwwILZ8K1c/bmVOhEhERUYPEhoGoDhSVlOHgqXTEaLQ4kXANQvlMqLCylKNPNy+olAqEdHKDhQWnQiUiIqKGjQ0DUS0xGAWcTrgOdZwWB06mobjUIC7r6t8KUWEKhAd5w9HOyoxVEhEREdUMGwaie6TNzIdao8XuOC2u5xaL416tHBClLJ8K1bOVgxkrJCIiIpKODQORBLkFJdh7PBV/abRI0OaI4w52Vugf7ANVmAKB7VryugQiIiJq9NgwEFWTvsyAI2czEaPRQhOfCYOx/MIEC7kMYYEeUCkV6NnFA9ZWFmaulIiIiKj2sGEgugNBEHD+8g2oNVrsPZ6KgiK9uKyDrwuilApEBvuihZONGaskIiIiqjtsGIhuIzNbh5g4LdQaLdKvF4rjrVxsMTDUF1FKBdp6OpuxQiIiIqL6wYaB6B+FRXrsP5kGtUaLM4lZ4riNtQX6dS+fCrV7BzdYyHldAhERETUfbBioWTMYjDh24RpiNFocOp2O0jIjAEAmA3p0aA2VUoG+3b1hZ8MfFSIiImqeuBdEzVLGjVL8/ft57D+ViZz8EnFc4eGIqDAFBoYq4NbSzowVEhERETUMbBio2cjOK0bs0RTsOnIZVzILxHFnB2tEhvhApVSgg28LToVKREREdItG2TD89ddf+Oyzz5CQkAAHBweEhYVh1qxZUCgUJuv9/PPP+OKLL5CWlgY/Pz/MnDkTUVFRZqqazKG4tAyHT2dAHafF8fNX8c9MqLCQA8pAd9zXux1CAz1gZSk3b6FEREREDVSjaxgOHz6MKVOm4KGHHsLMmTORk5ODjz76CM8++yy2bt0KW1tbAMD27dsxf/58TJ48GX369EF0dDSmTJmCDRs2IDg42LwvguqU0SjgTFIWYjRa7DuRhqKSMnFZ53auCO/hgVbWuQgN6gp7e3szVkpERETU8DW6hmH79u3w9vbGokWLxFNHXF1d8dRTT+H06dNQKpUAgI8//hjDhw/HjBkzAAB9+vTBhQsXsHLlSqxZs8Zc5VMdSr1WgBiNFjFxWly9USSOu7vaIyrMF6owBbzdHKHT6RAfn2/GSomIiIgaj0bXMJSVlcHBwcHkPHMnJycA5TfZAgCtVovk5GS8+uqrJo8dNmwY3n//fZSWlsLa2rr+iqY6k68rxd7jqVBrtDh/+YY4bmdjiYggb6iUCnTxawU5p0IlIiIikqTRNQxjxozBr7/+ig0bNuDBBx9ETk4Oli1bhi5duiA0NBQAkJiYCADw8/MzeWz79u2h1+uh1WrRvn37eq+daoe+zIi4c5lQa7T4+2wGygzljaJcLkNogDuiwnzRu5sXbKwszFwpERERUePX6BoGpVKJFStW4JVXXsFbb70FAOjcuTO++OILWFiU7yDm5uYCAJydTe/EW/F1xfLaIggCdDpdrW6zOoqKikz+35QJgoBLqXnYczwdB05lIF+nF5e183RCZIgXwrt7ooWTDQDAoC/BLauYaE651SbmJh2zk4a5ScPcpGFu0jA36cyZnSAINZoVstE1DEePHsXs2bPxyCOPYODAgcjJycGqVavwwgsv4LvvvhMveq5Per0e8fHx9f68FZKTk8323HUtp7AMp5J1OJGkw/W8mxcvO9rK0cPPHj3a2cOzpTUAHdJTEpFeg2035dzqEnOTjtlJw9ykYW7SMDdpmJt05squJqfnN7qGYeHChejTpw/mzp0rjgUHB2PgwIH49ddfMX78eLi4uAAA8vPz4ebmJq6Xl5cHAOLy2mJlZYUOHTrU6jaro6ioCMnJyWjXrh3s7JrOTcaKSspw5OxV7DmejjNJ2fjn0hRYW8nRs7M7IoO90N3fFRYW0qZCbaq51TXmJh2zk4a5ScPcpGFu0jA36cyZXUJCQo3Wb3QNw6VLlzBo0CCTMU9PT7Rs2RJXrlwBAPj7+wMov5ah4t8VX1tZWVW6X8O9kslkZp2e087OrtFPD2owCjh58RrUcVocPJWOklKDuKx7+9ZQKX3Rr4c37G2tau05m0Ju5sDcpGN20jA3aZibNMxNGuYmnTmyq+lNahtdw+Dt7Y2zZ8+ajKWmpuLGjRvw8fEBACgUCrRr1w47duzA4MGDxfWio6PRt29fzpDUgFxOz0NMnBYxcSnIzisWx71bO0DVU4GBoQp4uPIXEBEREZG5NLqG4dFHH8WiRYuwcOFCqFQq5OTk4NNPP0WrVq0wdOhQcb2pU6di1qxZaNOmDXr37o3o6GicPHkS69evN2P1BAA5+SXYcywF6jgtLqXcvADd0c4KkSE+UCkV6NSmZY27XyIiIiKqfY2uYfjPf/4Da2trfP/999i0aRMcHBwQHByM5cuXo2XLluJ6I0aMQFFREdasWYPPP/8cfn5+WLFiBUJCQsxYffNVqjfgyNkMqDVaxJ27CqOx/MIESwsZlJ09oFIqoOzsAStLToVKRERE1JA0uoZBJpNhwoQJmDBhwl3XHTduHMaNG1cPVdHtCIKA+ORsqDVa7DueisLim7McdWrTAqowBSKCfeDiaGPGKomIiIjoThpdw0ANX/r1QuyO00Idp0VG1s37U7RuYYeoMF9EhSmg8HAyY4VEREREVF1sGKhWFBTpse94KtQaLeKTs8VxOxsL9OvhDZVSgW7+rSGX87oEIiIiosaEDQNJVmYw4tj5q1BrtDh8JgP6MiMAQC4Dgjq6QaVUoE83L9ja8G1GRERE1FhxT45qRBAEXErNRYxGiz3HUpFTUCIua+PphEFKBQaE+qKVC2/eQkRERNQUsGGgasnKLcLuuPKpUK9k5IvjLo7WGBDqC1WYAv4+LpwKlYiIiKiJYcNAVSouKcPB0+lQa7Q4cfEahPKZUGFlKUfvrp5QKRUICXCHpYXcvIUSERERUZ1hw0AmjEYBpy5dh1qjxcFTaSgqMYjLuvi5QqVUIDzIB452VmaskoiIiIjqCxsGAgBoM/MRE6dFTFwKrucUieOereyhClNgYJgCXq0dzFghEREREZkDG4ZmLLegBHv/mQr1ojZHHHewtUREsA9USgU6t3PldQlEREREzRgbhmZGX2bA32czodZooYnPhMFYfmGCXC5DWKA7VEoFenXxhLWVhZkrJSIiIqKGgA1DMyAIAs5fuQG1Rou9x1JRUKQXl7X3dYEqTIHIEF+0cLIxY5VERERE1BCxYWjkbG1tq1yWma3D7jgt1Bot0q4XiuOuzraICvNFVJgCbb2c66NMIiIiImqk2DA0UsWlZbCytoWXrz+srG1QXFoGW2tL6Ir12H8iDeo4LU5fyhLXt7G2QN/uXlCFKdCjoxss5LwugYiIiIjujg1DI1SqN2BTTAK27k1EYZEeDnZWGBnhj1GR/nj90/1ISssDAMhkQPf2raFSKtC3uxfsbTkVKhERERHVDBuGRqa4tAybYhLww87z4lhhkR4//HkegiDgsfsD8c32s1ApFRgQ6gv3lvZmrJaIiIiIGjs2DI2MhVyOrXsTb7ts2/4kfPvm/ejd1ZNToRIRERFRrZCbuwCqmcJiPQpvmeXIZFmRHrriMjYLRERERFRr2DA0Mg62VnCwu/21CA52VrxOgYiIiIhqFRuGRsZgNOLB/v63XfZgf38YjMZ6roiIiIiImjJew9DI2Fpb4mFVRwDAb7fMkvRgf388rOrIOzQTERERUa1qlA3Dk08+iSNHjtx22bJlyzB8+HAAwM8//4wvvvgCaWlp8PPzw8yZMxEVFVWfpdYJaysLjInqgHGDOqFAVwJHexsYjEY2C0RERERU6xplw/DGG2+goKDAZOybb77Bzp070bdvXwDA9u3bMX/+fEyePBl9+vRBdHQ0pkyZgg0bNiA4ONgMVdcuW2tL6HQ6pGmT4OfnB3t7Tp9KRERERLWvUTYMHTp0qDT2yiuvIDw8HK6urgCAjz/+GMOHD8eMGTMAAH369MGFCxewcuVKrFmzpj7LrVPFxcXmLoGIiIiImrAmcdHz0aNHkZKSgpEjRwIAtFotkpOTMXToUJP1hg0bhoMHD6K0tNQcZRIRERERNTpNomHYtm0b7O3tMWjQIABAYmL5jc38/PxM1mvfvj30ej20Wm2910hERERE1Bg1ylOSblVWVobff/8dKpVKPI8/NzcXAODs7GyybsXXFctriyAI0Ol0tbrN6igqKjL5P1UPc5OGuUnH7KRhbtIwN2mYmzTMTTpzZicIQo1u9NvoG4b9+/cjOzsbI0aMMMvz6/V6CIKA+Ph4szw/ACQnJ5vtuRsz5iYNc5OO2UnD3KRhbtIwN2mYm3Tmyq5ZNQzbtm1DixYtEBERIY65uLgAAPLz8+Hm5iaO5+XlmSyvDRVhW1nxDstERERE1PDp9frm0zAUFxdj165dePDBB0122P39y++EnJiYKP674msrKysoFIpaqyEkJKTWtkVERERE1NA06oue1Wo1dDqdODtSBYVCgXbt2mHHjh0m49HR0ejbty+sra3rs0wiIiIiokarUR9h2Lp1K7y9vREWFlZp2dSpUzFr1iy0adMGvXv3RnR0NE6ePIn169eboVIiIiIiosap0TYMubm52Lt3L5566qnbnoM1YsQIFBUVYc2aNfj888/h5+eHFStW8BQiIiIiIqIakAmCIJi7CCIiIiIiapga9TUMRERERERUt9gwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEBERERFRldgwEFGDkJGRgZSUFHOXQUR3kZmZCQAwGo1mroSI6gsbBqokPz8f33//Pfbv34+rV6+K44IgmLGqhq+goAA//vgjduzYgQsXLsBgMABgbneTn5+P2bNn4z//+Q+2bNmC7Oxsc5fUKOTn52PTpk3QaDQmmfH9dncFBQVQq9W4cOEC8vLyzF1Oo5GXl4cpU6ZgwIAByM7OhlzOXYjqyM/Px+rVq7FmzRrs3bsX+fn5APizejeFhYVISkoydxmNTl3tw1nea2HUtPz8889YtGgR3N3dkZOTAycnJzz33HOYMGECZDKZuctrsD7//HN88cUXcHV1RVZWFmxsbPDCCy/gP//5D3O7gxMnTmD27Nlo3bo1Jk+eDH9/f7Rs2dLcZTV43377LZYtW4aWLVsiJycHbm5umDhxIsaNG8f32118/vnnWLduHRwcHJCSkgI/Pz/Mnj0bkZGR5i6tQVuxYgU+++wzBAUF4fPPP0eLFi3MXVKj8P3332PZsmXw8fGBTqfDjRs3MGrUKMybN48/q3fwww8/4M0338SQIUOwYMECtG7d2twlNQp1uQ/HhoFEqamp2LBhAyZNmoTRo0cDABYtWoRVq1ZBLpdj/PjxEASBv+RukZmZibfeeguXLl3CzJkz0a9fP9ja2mLevHnYvHkzwsPD0b59e3OX2WD99ddfaNOmDRYsWAAvLy9YWt78lcT32u2dPHkSX331FaZNmwaVSgW5XI4333wTS5cuhUwmw8MPP8zsbiMnJwcfffQRDh06hGnTpqFr167Q6/WYNWsW1qxZAx8fH/6s3salS5fw/PPPIycnB4sWLUJkZCSbhWo6fvw4vv76a7z00ksYPnw4bG1t8fHHHyMmJgbDhw9HSEiIuUtscHQ6Hb7//nts2LABHTp0wN69e6HRaDBkyBAe0bqLut6HY/okunjxIpKSktCvXz94eHjAw8MDr776KgYOHIjFixcjPT2dOyH/YmVlhaysLEybNg0PP/wwfH194eHhgdGjRyM5ORmOjo7mLrHBKi0txS+//IJBgwZBoVDA0tISaWlpOHr0KHQ6Hd9rVdi9ezcMBgMGDx6Mtm3bQqFQ4NVXX0W7du2wePFiZGZmMrvbuHLlCv766y888cQTGD16NLp27Yrg4GDMnj0bx48fNzl0Tzc5ODggJycH4eHh6N27t9gsFBQUmLewRuDPP/9ESUkJoqKi4ObmBicnJ0RFRSErKwt2dnbmLq9BMhqNiI6ORmBgIFasWIFu3bph7dq1SEtLM3dpDV5d78OxYSDR9evXYWdnZ/Lpka+vL5588kl4enpi8eLFAHjeZQVBEODq6op33nkHw4YNg5WVFSwsLACU/zFVqVQmfxSY202CIODatWtwcXFBy5YtYTAY8Prrr2PkyJGYOnUqHn30UXz99dfmLrNBys/Ph7OzMxQKBYxGIwRBQGBgIPr374/CwkKsWrUKAN9v/9ayZUvMnTsXjz/+OKysrAAABoMBPXv2BHDzQl66yWAwwNPTE5MnT8axY8dw7NgxCIKA//3vf3jqqafwxBNPYOXKlZys4F9u/dmTyWRwcnISvy4rK0PPnj1N/s7yZ7WcIAhwdHTEW2+9hVWrVqFdu3Z4+eWXcfr0aezcuROlpaXmLrFBq+t9ODYMzdCPP/6IxYsX48cff8SlS5fE8T59+qCgoADnzp0DAOj1egCAv78/nnvuOezcuRNnzpyBTCZrlr/g/p1bRQ7/Po3h008/xf/+9z+cOnUKI0aMwHvvvSd+6svcyt9vMpkMHh4eyM7ORnp6OtauXYtTp07hnXfeweuvv46uXbvi3XffxZ9//mnm6s2nqp9TpVKJixcv4tixY5DL5eIfUT8/P/Fx58+fb7bvNwDYtWuXmFlZWRmA8j+cw4YNA3Bzdh8LCwtcv34dMpkMXl5e5im2Abk1N6PRKJ4CMnHiRLi5uWHp0qXo06cP4uLi0K1bN9jZ2eHTTz/F/Pnzm3XD9e/cKjz66KPIysrC66+/jujoaKxevRqTJk1CQkICRo8ejddeew2pqanN9mc1OjoaP/30E/7880/x029BENC1a1cA5T+7ISEhGD16NNatW2fye7A5M9s+nEDNRkZGhjB+/HghIiJCmDx5stCzZ09hwIABwoEDBwRBEIS8vDzhqaeeEkaNGiU+xmg0CoIgCFeuXBHGjBkjTJkyxRylm1VVuR08eFBcx2AwCGVlZcKGDRuE8PBwYc2aNcKePXuE5cuXC1FRUcKzzz5rxldgHnfKreJ9NX/+fKFXr17CiBEjhJ9//ll8bG5urvDyyy8LQ4YMEfLy8sz1Eszibj+nly9fFh555BFh5MiRQmFhofi4uXPnCtOmTRMmTJggzJ0711zlm9W5c+eE8ePHCwEBAcKCBQuq9ZiDBw8KPXv2FM6fP1/H1TVcd8qtrKxMEARB2LFjh9C3b19h1apVQlZWllBaWioIgiCsX79eUKlUwsKFC+u9bnOrKreK32+CUJ7b7NmzhUcffVTo2bOn8PXXXwunTp0SvvrqK2HIkCHCo48+ao7Szero0aPCyJEjhf79+wtjxowRAgIChHHjxgmXLl0SBOHme65Cenq6EBYWJrz99ttCfn6+IAimGTcX5t6H4xGGZuTgwYPIzc3Fp59+ilWrVmHDhg3o0aMHZs2ahb///htOTk548MEHcfHiRfzyyy8Abn465+HhAaVSiZSUlGb3SdKdcjt8+DAAQC6Xw8LCAoMGDcLWrVsxceJE9O/fH9OnT8cTTzyBI0eO4NSpU2Z+JfXrTrkdOXIEADBixAg4ODjg4sWLaNOmDYCbh6UnTJiAy5cv4+jRo+J4c3Cn3DQaDdq0aYMXX3wRV69exejRo7FgwQI8+uij2LVrF8aOHYsOHTqgpKQEJSUl5n4p9SopKQmLFi1CXl4eunfvjmPHjmHv3r0Abn+/gIqxU6dOwcbGBr6+vvVab0Nxt9wqTrO8//77MWPGDIwaNQqurq7iaV1jxoxBx44dcfTo0Wb1t+FOud36u+r+++/He++9B1tbW4wfPx5PPvkkunXrhqeffhqTJk3CsWPH8Pfff1d6XFN18OBBLFy4EN27d8dXX32Fb775Bh999BHy8vLw/vvvA4D4nqvg6emJF154ARs3bsSJEycAoFlep2XufTg2DM1ITEwMXFxc0K1bN8hkMnTs2BFLliyBnZ0dVq5cibS0NAwcOBCRkZF4//33UVxcDCsrKwiCAGtra7Rp0wZZWVnNboaMqnKztbXF6tWrTQ4Jenh4iNOCVvzy9/f3h6WlpfiD21zcKbdPP/0UWq0WQUFBuP/++wEAFy5cQHFxMWQyGeRyOZycnODi4oLr168DaD5/IO70c7pixQpcvnwZAwYMwOeff45evXohLi4Obdu2xXfffYfIyEi0atUK2dnZsLGxMfdLqVdZWVkwGo2YMWMG5s+fD0EQsGnTJpSWlkIul1faGas43ebkyZMICgqCvb09jEYjjEYjMjIyzPESzKI6uVVk98gjj8Db2xtA+e83o9EIOzs7dO7cGVevXoWLi4s5X0q9qsn77cqVKzh79ixGjhwJuVwu/i1o164dHBwcxPdbc/gdt2vXLhgMBkycOBH+/v5wdHTE4MGDMWDAACQmJkKr1d72cU888QQ8PT2xfv16XL9+HQUFBTh58mQ9V29e5t6HY8PQTBgMBvHCq8LCQgDl57dZW1vjf//7H+Li4vD777/D1dUVzzzzDORyOebOnYucnBzIZDKUlZXh8uXL8PT0FM+Law7ultvff/+N3bt3i38Abv0kUyaToaCgAPv27YOPjw/atm1b/y/ATKrzftu5cyesra3x6KOPonPnzvjxxx9x+vRpAOWfisTHx8PKygpBQUFmex31rTq5/fnnnygtLUWPHj3w9ttvY8uWLXjvvffQsWNHZGZmIjY2FoGBgQCa1514u3btik8//RRDhgxBjx49EBkZiTNnzuDXX3+t8jElJSXQarXo0KEDgPJpCd944w1MmzYNFy9erK/Szao6ud26I2swGMSpGeVyObKysnDo0CG0a9euWezwVqjJ+83S0hIymQxbtmwRvy4rK8OZM2fg4OCALl261Hf59a7id9HTTz+NJUuWwM/PT9y3sLCwgI+PD/Ly8kwuEK8gCALs7e0xa9Ys7N27Fxs2bMCcOXPw0ksvNZumoSHsw7FhaCYsLCzQunVrXLt2TfxDWNF5hoeHIzw8HFu2bEFKSgp69eqFt956C3/++SemTZuGNWvW4Ouvv8avv/6KoUOHNqupQquT2y+//CJ+KlLxqWVhYSEyMzPx3XffITY2FhMmTICrq6vZXkd9q0lubdu2xeLFi5GTk4PXXnsNCxYswIcffoj33nsPAwYMgLe3d7M4VA9UL7dff/0Vqamp4mOsra1RUFCAzMxM/PzzzygtLcWIESMAoFnNW25nZwdHR0fxj+GTTz4JV1dXbNu2TZx04N8NVFZWFi5fvgx/f3/8+OOPePjhh3HgwAG88sor6NixozleRr2raW4WFhaQyWTQ6XTIzMzE999/j5SUFDz22GPN6qhWdXIzGAwAAGdnZ4waNQrffPMNvvjiC+zcuRPr1q3D6tWr8cADD8DHx6fJ/46r+F2kUCjQoUMH8fVW3HtHr9fD3t7+tjnIZDLo9Xr4+fmhRYsW+PTTT5GUlIQlS5agR48e9fcizKhB7MNJvvqBGg2DwSAIgiBcvXpV6NKli/DRRx8JRUVFgiAI4oVrFy9eFAICAoQ///xTfJxarRZmzpwpPPTQQ8KQIUOEDRs21H/xZiQlt9LSUuH3338Xpk2bJowaNUro1auXsHnzZvO8ADOR+n6Lj48Xli5dKjzzzDPCmDFj+H6rRm5Go1FISkoS3n33XfH99ssvv5jnBTQgFRf6bdiwQVCpVMInn3xiMl4hOjpaCAgIEEJDQ4WgoCBh3bp19V5rQ1Kd3MrKyoTt27cLL7/8sjBixAhBqVQKGzduNEu9DUV1csvIyBDmz58vhISECFFRUcJ9990nfP/992aptyG5dQKMCRMmmIxVKCkpEbZv3y5ERkYKSqVS2LJlS32XWS+qupC7oezDsWFoAtLT0++6TsUb7q233hLCw8OFEydOiMv0er1gMBiEcePGCa+++mqlx2ZmZoqPb0rqIje9Xi8cOHBAmDNnjrBy5UpBr9fXTfFmVNfvN51O1yRnwKjL3FavXi2sXr26Sb7fBKF62d2q4v1TUlIiTJo0SRg9erRw8uRJQRAEk99larVaCA4OFt59990mmV1d5FZaWipER0cLkydPFpYvX87chDvn9u8ZfzIyMoTjx49XGm8KaprbrYYOHSq8++67giAIt93fWLJkibB48eIm+X47fPiwcPnyZSErK6vKdRrCPlzzOV7dBO3duxe9evXCq6++ivz8/DuuW3E48KWXXoLBYMDXX38tntZQcX6lg4MDLCwsxPPxhX8ODbq7uzepUxvqKrfS0lJYWlqiT58+eOutt/Diiy+Kh1ubgrp+v1Wws7NrUudC12VuFac8PPfcc3jhhRea1PsNqFl2t6o4jcba2hrjx49HYWEhNm7ciNLSUpw6dUo877lbt27466+/MGfOnCaVXV3mZmVlhUGDBmHZsmWYPn06c8Odczt9+rQ4Q54gCPDw8EBQUFClmYAaM6m5AeXXNmRmZiIzMxPdunUDUP57MDU11WTygWnTpmHu3LlN6v0WHR2NIUOG4I033sDo0aPxyCOP4MiRI7e99qwh7MM1nb3AZqSsrAwbN27EwoUL0aJFCxw9ehR//fXXXR8n/HNn4v/+97+IiYnBV199JS67evUq0tPTERAQIP5ANqWdNqDuc7O2tgZQnlvFv5uC+nq/NTX1kVvFTkdT2vkApGd3q4rfX1FRUVAqlTh8+DBeffVVjB8/HitWrIDBYICbm1uTuraovnKztrY2uYt9Y1dfufFvamVyuRxarRYlJSUIDg5GUVERfvjhB9x///14++23xfUqpvFtCoqLi7Fq1SosWbIEw4YNw+LFi/Hee+/BxcUFCxcurPIGdebeh2uaf6mbOEtLS/z222+wtbXF66+/jp9++gkrV65Ev3794O7uXuXjKt48I0aMwIULF/Dbb7/hwIEDCA8PF+c2Dg8Pr5fXYA7MTRrmJg1zk05qdrequOi0pKQEXl5eSE5OxtWrVzFr1ixMnDixjl+BeTA3aZibNLWRGwAcOnQIbdu2RUJCAj766CNcvHgR06ZNwwsvvFCH1ZtPamoq/vzzTwwfPhwvvPAC7O3tAZTfjf6hhx5CcnIyOnbsaHK3daAB/G2455OaqF5VnL937tw58S6vp0+fFkJCQoTly5ff9fEV57GVlJQIp06dEubOnSs8//zzwoIFC0zuGtvUMDdpmJs0zE26e83uVllZWcLzzz8v3olXp9PVer0NBXOThrlJUxu5GY1GQa/XC88995wQEBAgBAYGCi+//LJQUFBQZ3U3BJcuXRK+++47oaSkRBwrLS0Vbty4IURGRgoff/xxlY81598GmSA08bm8GrnY2FicPHkSXl5eCA8Ph5eXFwCYdJ6lpaVYuXIlvv32W3z//fcICAi463aFf+bRrnh8UzqFBmBuUjE3aZibdHWVHQDk5+fjp59+Qt++fZvcXPfMTRrmJk1d5Fbx+23BggU4c+YM3n//fbRv377OX0t9ujW3fv36iTc+1Ov1sLKyMskvLy8PAwYMwFtvvYWRI0fecbtm+dtQp+0ISVZQUCBMnz5dCA4OFp599lmha9euwogRI4Rff/1VXOfWmWS0Wq0wePBg4eWXXxan2WqOmJs0zE0a5iYds5OGuUnD3KSpy9wqPi1virMwVie3fzt37pwQGhoqHDp0qB4rrT42DA3U3r17hSFDhgh79uwRSkpKhPj4eGH27NlCjx49BI1GI65X8YNqNBqFn376SQgMDBRiY2PNVbbZMTdpmJs0zE06ZicNc5OGuUnD3KSpbm6CcLNh2r59uxAUFCRkZGSYo+S74ixJDdThw4dRVFSE/v37w9raGoGBgZg7dy66deuGxYsXIzk5GcDNi2BkMhkGDRoEpVKJlStXorCwEDqdDpcuXUJxcbEZX0n9Ym7SMDdpmJt0zE4a5iYNc5OGuUlT3dyAm9nFxcWhU6dO8PDwEJfl5OSIdxM3NzYMDZRer4ebmxuuXbsGoPx8tZYtW+LNN9/E2bNnsX37dpSUlIjLAMDV1RUvvvgizp49iy+//BIffPABXnrpJRw8eNBsr6O+MTdpmJs0zE06ZicNc5OGuUnD3KSpSW4ymQyCICA5ORmBgYEAgOzsbKxYsQJTp07F6dOnzfY6bsWGoYGp+IHr0KEDLl26JN6Yo+LGMB07dsRjjz2Gn376CZmZmeKyCu7u7ujYsSNWrlyJ7du3Y+LEiYiKiqr/F1LPmJs0zE0a5iYds5OGuUnD3KRhbtJIyQ0ov2D+woULaNu2Lfbu3YsJEybgyy+/xMiRIxESEmKW11JJPZ36RDVUXFwshIeHC2+//bZ4C/mKcwRTUlKEoKAg4fvvvxcEofzW82VlZcK+ffuEsWPHCgEBAcInn3xittrNiblJw9ykYW7SMTtpmJs0zE0a5iZNTXITBEHQaDRCQECA0K9fPyEwMFB4++23zVL3nfAIQz2rOBdNuMtstjY2NnjyySexceNGnD17FsDNw1aurq6IiIhAdHQ0gPK7vFpYWODYsWPw9PRETEwMpkyZUrcvpJ4xN2mYmzTMTTpmJw1zk4a5ScPcpKmL3IDyqVEdHR0RGhqKmJgYzJs3r+5ehERsGOrJ6dOn8eqrr0KtVgOo+pbdgiDAYDAAAEaNGgVfX198/PHHuHr1qvg4Ozs7WFhYwMnJCaWlpSgrKwMATJo0CStWrBDnR24KmJs0zE0a5iYds5OGuUnD3KRhbtLUVW4V1zF06tQJGzduxCeffAJPT896eEU1x4ahjpWVleG7777Dc889h61bt0KtVovnrf27Qy0rK4NMJoOFhQUKCgrg6emJ2bNnY+/evfjyyy+Rn58PoPxct6tXr8LLywvW1tawtLQEAFhZWdXvi6tDzE0a5iYNc5OO2UnD3KRhbtIwN2nqOjcbGxsAQKtWrdCuXbt6fW01xYahjh0/fhzfffcd+vTpg2effRa//fabOFPAvzvUih+2Dz74AEqlEsnJyYiMjMSMGTOwc+dOjBs3DitWrMDs2bNx5coVPPDAA/X+euoLc5OGuUnD3KRjdtIwN2mYmzTMTRrmdou6vUSi+aq4yOXSpUvCu+++K2RmZgqCIAgjR44Uxo8fLyQkJAiCYHqHxD///FPo0qWLMGzYMOHnn38WiouLxWVHjx4VZsyYITz77LPCpEmThMTExHp8NfWHuUnD3KRhbtIxO2mYmzTMTRrmJg1zq4wNQy1KSUkRzp49KxQVFVW5zt9//y0EBAQIn3/+uVBSUiIIws27/O3fv1947733hKysrCofX1BQULtFNwDMTRrmJg1zk47ZScPcpGFu0jA3aZjbnckE4S6XetNdlZSU4M0334RarYadnR1cXV3x6KOP4pFHHhHXMRqNkMlkkMlkmDp1Ks6cOYOlS5c2nPl1zYC5ScPcpGFu0jE7aZibNMxNGuYmDXOrHktzF9AUrFy5EkePHsXSpUtRUFCAQ4cOYcGCBdDr9XjooYfg4OAg3rTDwsICCxYswIABA7Bt2zb4+fmhRYsW5n4JZsHcpGFu0jA36ZidNMxNGuYmDXOThrlVk7kPcTR22dnZwqBBg4SPPvrI5Fy2+fPnCwMGDBC2bNlisn7FeXHLli0TgoODhZiYGEEQBKG0tFQ8vFWxTlPG3KRhbtIwN+mYnTTMTRrmJg1zk4a5VR9nSbpHdnZ2yM/Ph5eXF2QyGUpLSwEA//3vf9GqVSv8+uuvSEhIAHDzkBYAzJw5Ew4ODvjxxx9x9OhRfPPNN1iyZAmA8pufNHXMTRrmJg1zk47ZScPcpGFu0jA3aZhb9bFhuEe5ubnw8/PD0aNHUVZWBmtra+j1etjY2GDixIlITEwUb/Qhl8shl9+MfOrUqYiJicGLL76IDz/8EI6OjuZ6GfWOuUnD3KRhbtIxO2mYmzTMTRrmJg1zqz42DPfIw8MDbdq0wdmzZxEfHw/gZnc5dOhQtGvXDvv27UNGRob4mNLSUhw+fBj79+8HAAwcOBB79+7FtGnT6v8FmAlzk4a5ScPcpGN20jA3aZibNMxNGuZWA+Y+J6opiI+PFwIDA4VPPvlEnI6rtLRUEARB2L17txAQECAkJSWJ6yclJQkTJkwQBg0aJBw9etQcJTcIzE0a5iYNc5OO2UnD3KRhbtIwN2mYW/WwYagls2bNEiIjI4U9e/YIgnDzZh7Z2dlC7969TS6cKSkpEc6cOWOOMhsc5iYNc5OGuUnH7KRhbtIwN2mYmzTM7e54SlItWbBgAQDgu+++w4ULF8QLY86dOwe9Xg9PT08AgCAIsLa2RpcuXcxWa0PC3KRhbtIwN+mYnTTMTRrmJg1zk4a53R0bhlri5OSE2bNnQ6vVYu7cuThy5AhOnz6N6OhodOjQAR06dAAA8U1I5ZibNMxNGuYmHbOThrlJw9ykYW7SMLe7452ea9mhQ4fw/vvvIzMzE4IgwMnJCYsXL0ZoaKi5S2vQmJs0zE0a5iYds5OGuUnD3KRhbtIwt6qxYagDOp0OWVlZSE9PR69evcxdTqPB3KRhbtIwN+mYnTTMTRrmJg1zk4a53R4bBiIiIiIiqhKvYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioiqxYSAiIiIioipZmrsAIiJqenbs2IHp06ffdlnHjh2xbdu2eq6IiIikYsNARER1ZvLkyfD39xe//uyzz8xYDRERScGGgYiI6ky/fv3Qu3dv8euNGzfixo0bZqyIiIhqig0DERHVOr1eDwCQy+98qVxOTg5Wr16Nffv2ISUlBTKZDKGhoZg1axYCAwMBAIcPH8Z//vOfO25nypQpmDp1KlJTU7FmzRocPHgQ6enpsLOzQ+/evTF79mz4+vrWzosjImpm2DAQEVGtq2gYrK2t77ieVqvFrl278MADD8DX1xfXr1/Hjz/+iCeeeALbt2+Hh4cH2rdvj/fff198zE8//YRLly7htddeE8cCAgIAAKdOncKxY8cwfPhweHp6IjU1Fd9//z3+85//YPv27bCzs6uDV0tE1LSxYSAiolqXn58PALCxsbnjegEBAfjjjz9MjkSMGjUKQ4cOxcaNG/HSSy+hdevWGDVqlLi84ujBrWMVBg4ciAceeMBkLCoqCuPHj8cff/yBhx566B5eFRFR88RpVYmIqNbl5OQAAFxdXe+4nrW1tdgsGAwG3LhxA/b29vDz88PZs2dr/Ly2trbiv/V6PW7cuIE2bdrA2dlZ0vaIiIhHGIiIqA6kpaXB0tLyrg2D0WjEunXr8N133yElJQUGg0Fc1qJFixo/b3FxMVavXo3NmzcjMzMTgiCIyyqOehARUc2wYSAiolqXlJQEX19fWFre+c/MZ599ho8++ghjx47F9OnT4eLiArlcjkWLFpns7FfX22+/jc2bN+Opp55CcHAwnJycIJPJMHPmTEnbIyIiNgxERFTLSktLER8fj8GDB9913T/++AO9e/fGokWLTMbz8vLQsmXLGj93xXUKc+fOFcdKSkp4dIGI6B7wGgYiIqpVW7duRWlpKfr27XvXdS0sLCp98v/7778jMzNT0nNbWFhUGvv2229NTnUiIqKa4REGIiKqFTqdDuvXr8fKlSvFRuDXX381Wef69evQ6XT49ddfER4ejoEDB2LlypV47bXXEBISggsXLmDr1q1QKBSSahg4cCB+/fVXODo6okOHDjh+/DgOHDgg6XoIIiIqx4aBiIhqRXZ2NpYuXSp+vWDBgirXnT17NtatW4fJkyejqKgIW7duRXR0NLp06YLVq1ebbKcm/vvf/0Iul2Pr1q0oKSlBaGgovvrqK0ycOFHS9oiICJAJvAqMiIhqQUpKCgYNGoR169ahd+/e97weERE1DLyGgYiIiIiIqsSGgYiIaoW9vT1GjhyJ1q1b18p6RETUMPCUJCIiIiIiqhKPMBARERERUZXYMBARERERUZXYMBARERERUZXYMBARERERUZXYMBARERERUZXYMBARERERUZXYMBARERERUZXYMBARERERUZXYMBARERERUZX+H/+EYGAWlI/GAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "sns.lineplot(data=daily_growth, x='date', y='cumulative_volume_mb', marker='o', ax=ax)\n",
+    "ax.set_title('Кумулятивный рост объёма данных')\n",
+    "ax.set_xlabel('Дата')\n",
+    "ax.set_ylabel('Объём, МБ')\n",
+    "plt.xticks(rotation=30)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3ee5cfc1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.301921Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.301454Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.308388Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.307519Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "- **Размер исходного CSV:** 143.84 МБ (~284807 записей).\n",
+       "- **Средний объём данных за день:** 71.92 МБ, что даёт 25.64 ГБ в год.\n",
+       "- **Порог 1 ТБ будет достигнут примерно через:** 479.3 месяцев при текущей скорости роста (~40 лет).\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "summary_md = f\"\"\"\n",
+    "- **Размер исходного CSV:** {volume_stats['csv_size_bytes'] / 1024**2:.2f} МБ (~{num_rows} записей).\n",
+    "- **Средний объём данных за день:** {volume_stats['avg_daily_mb']:.2f} МБ, что даёт {volume_stats['yearly_volume_gb']:.2f} ГБ в год.\n",
+    "- **Порог 1 ТБ будет достигнут примерно через:** {volume_stats['months_to_tb']:.1f} месяцев при текущей скорости роста (~40 лет).\n",
+    "\"\"\"\n",
+    "display(Markdown(summary_md))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "882d5195",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.311665Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.311361Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.323682Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.322636Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Показатель</th>\n",
+       "      <th>Значение</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Годовой объём (Parquet)</td>\n",
+       "      <td>25.64 ГБ</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Стоимость хранения за год</td>\n",
+       "      <td>369 ₽</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Дней до накопления ~5 ГБ</td>\n",
+       "      <td>71 дней</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  Показатель  Значение\n",
+       "0    Годовой объём (Parquet)  25.64 ГБ\n",
+       "1  Стоимость хранения за год     369 ₽\n",
+       "2   Дней до накопления ~5 ГБ   71 дней"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "cost_per_gb_month = 1.2  # RUB, тариф Yandex Object Storage Standard (предположение)\n",
+    "yearly_storage_cost_rub = volume_stats['yearly_volume_gb'] * cost_per_gb_month * 12\n",
+    "\n",
+    "spark_threshold_gb = 5\n",
+    "spark_days = spark_threshold_gb * 1024 / volume_stats['avg_daily_mb']\n",
+    "\n",
+    "cost_table = pd.DataFrame([\n",
+    "    {'Показатель': 'Годовой объём (Parquet)', 'Значение': f\"{volume_stats['yearly_volume_gb']:.2f} ГБ\"},\n",
+    "    {'Показатель': 'Стоимость хранения за год', 'Значение': f\"{yearly_storage_cost_rub:,.0f} ₽\"},\n",
+    "    {'Показатель': 'Дней до накопления ~5 ГБ', 'Значение': f\"{spark_days:.0f} дней\"},\n",
+    "])\n",
+    "\n",
+    "volume_stats['yearly_storage_cost_rub'] = yearly_storage_cost_rub\n",
+    "volume_stats['spark_days'] = spark_days\n",
+    "\n",
+    "cost_table\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1f0a5f5",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**Горячие vs холодные данные.** При среднем объёме ~72 МБ/сутки целесообразно хранить последние 30 дней (~2.1 ГБ) в оперативно доступном слое (например, в объектном хранилище + таблицы Delta Lake) для онлайн-моделей. Исторические данные старше 90 дней можно архивировать в холодное хранилище (Iceberg/Glacier) с более дешёвым тарифом, сохранив возможность периодического переобучения.\n",
+    "\n",
+    "**Переход от Pandas к Spark.** Порог ~5 ГБ (~9.6 млн строк) будет достигнут через ~71 дней. Для обучения и инференса модели, учитывающей temporal features, уже на горизонте квартала рационально планировать миграцию на распределённую обработку (Spark/Flink), чтобы выдержать рост и расширение фич.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6619b148",
+   "metadata": {},
+   "source": [
+    "## 2. Velocity (скорость поступления данных)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3362a36c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.327161Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.326853Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.438852Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.437745Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Метрика</th>\n",
+       "      <th>Значение</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Среднее событий/сек</td>\n",
+       "      <td>1.65</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Std событий/сек</td>\n",
+       "      <td>1.56</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Коэффициент вариации</td>\n",
+       "      <td>0.95</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Пиковая нагрузка (5 мин окно)</td>\n",
+       "      <td>1376</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Среднее событий/час</td>\n",
+       "      <td>5933</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Максимум событий/час</td>\n",
+       "      <td>9895</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         Метрика Значение\n",
+       "0            Среднее событий/сек     1.65\n",
+       "1                Std событий/сек     1.56\n",
+       "2           Коэффициент вариации     0.95\n",
+       "3  Пиковая нагрузка (5 мин окно)     1376\n",
+       "4            Среднее событий/час     5933\n",
+       "5           Максимум событий/час     9895"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "base_time = pd.Timestamp('2013-01-01')\n",
+    "df_time = df.assign(event_time=base_time + pd.to_timedelta(df['Time'], unit='s'))\n",
+    "\n",
+    "per_second = df_time.set_index('event_time').resample('1s').size()\n",
+    "full_range = pd.date_range(per_second.index.min(), per_second.index.max(), freq='1s')\n",
+    "per_second_full = per_second.reindex(full_range, fill_value=0)\n",
+    "\n",
+    "per_second_stats = {\n",
+    "    'mean_rps': per_second_full.mean(),\n",
+    "    'std_rps': per_second_full.std(ddof=0),\n",
+    "    'cv': per_second_full.std(ddof=0) / per_second_full.mean(),\n",
+    "}\n",
+    "\n",
+    "per_five_min = df_time.set_index('event_time').resample('5min').size()\n",
+    "per_hour = df_time.set_index('event_time').resample('1H').size()\n",
+    "\n",
+    "velocity_table = pd.DataFrame([\n",
+    "    {'Метрика': 'Среднее событий/сек', 'Значение': f\"{per_second_stats['mean_rps']:.2f}\"},\n",
+    "    {'Метрика': 'Std событий/сек', 'Значение': f\"{per_second_stats['std_rps']:.2f}\"},\n",
+    "    {'Метрика': 'Коэффициент вариации', 'Значение': f\"{per_second_stats['cv']:.2f}\"},\n",
+    "    {'Метрика': 'Пиковая нагрузка (5 мин окно)', 'Значение': int(per_five_min.max())},\n",
+    "    {'Метрика': 'Среднее событий/час', 'Значение': f\"{per_hour.mean():.0f}\"},\n",
+    "    {'Метрика': 'Максимум событий/час', 'Значение': int(per_hour.max())},\n",
+    "])\n",
+    "\n",
+    "velocity_stats = {\n",
+    "    'per_second_series': per_second_full,\n",
+    "    'per_five_min_series': per_five_min,\n",
+    "    'per_hour_series': per_hour,\n",
+    "    'peak_5min': int(per_five_min.max()),\n",
+    "}\n",
+    "\n",
+    "velocity_table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "03ae3757",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.441908Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.441433Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.717081Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.715668Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3IAAAGACAYAAADoElDaAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAsANJREFUeJzs3Xd4k1X7wPFvku49gZYWumhpoaUte4sgCDJ82SggL8MNL7j15/YV9FVEEWSJE1FRwQUigggClb0LlC46aEtL906b/P4ojdSWlSZNx/25Lq62yZPz3Dmkae7nnHMfhVar1SKEEEIIIYQQoslQmjoAIYQQQgghhBC3RhI5IYQQQgghhGhiJJETQgghhBBCiCZGEjkhhBBCCCGEaGIkkRNCCCGEEEKIJkYSOSGEEEIIIYRoYiSRE0IIIYQQQogmRhI5IYQQQgghhGhiJJETQgghhBBCiCZGEjkhhBBCNDorV65Eo9EAoNFoWLVqlYkjEkKIxsXM1AEIIURD2rhxI88++6zuZwsLCzw9Penbty8PP/wwbm5uJoxOCFFt06ZNqFQqRo0axc8//8ymTZt44IEHTB2WEEI0GpLICSFapHnz5uHl5UV5eTmHDx/myy+/ZNeuXfz8889YW1ubOjwhWrz//Oc/PPXUU7z99ttYWFjw1ltvmTokIYRoVCSRE0K0SAMGDCA0NBSACRMm4OTkxMcff8yOHTsYOXKkiaMTQowYMYKePXty4cIFfHx8cHFxMXVIQgjRqMgaOSGEAHr16gVASkoKALm5ubz55puMGjWKiIgIIiMjmT17NmfPnq312LKyMt5//32GDRtGaGgo/fr149FHHyUpKUnXZlBQ0DX/TZs2TdfW/v37CQoKYsuWLbzzzjv07duX8PBwHnzwQdLS0mqd+/jx48yaNYuuXbvSpUsXpk6dyuHDh+t8jtOmTavz/O+//36tY3/44QfGjh1LWFgYPXr0YMGCBXWe/3rP7WoajYZPPvmEu+66i9DQUPr06cOLL75IXl5ejeNuv/32OqfPvfrqq7XarCv2Dz/8sFafApSXl7N06VLuuOMOOnfuzMCBA/nf//5HeXl5nX11oz6r63kGBQXx6quv8uOPP+peC2PHjuXgwYM12kxNTeXll19m2LBhhIWF0bNnT+bNm6d77VXbuHEjQUFBnDx5ssbt2dnZtZ77+vXrGT16NF27diU8PJzRo0fzzTff1Hjc2bNneeaZZxg8eDChoaH07duXZ599lpycnBrHvf/++7X6+q+//qJz5868+OKLtY7Lzs6ucezJkycJCgpi48aNutuqXydX3wbwyiuvEBQUxDPPPFPreaekpODq6kpkZCROTk6MGjWqzjb+qfrx1/r3z9dMdHQ0s2fPJjIykoiICO677z6OHTt23XP8M86rTZs2rcbrr7y8nPfee4+xY8fq/n/uuece/vrrr1ptajQaPv30U0aNGkVoaCi9evVi1qxZNV4D3333HdOnT6d379507tyZESNGsH79+lpt3X777QQFBfH666/Xum/WrFkEBQXJVFUhmjgZkRNCCNAlXU5OTgAkJyezfft27rzzTry8vMjKyuLrr79m6tSpbN68mdatWwNQWVnJAw88QFRUFHfddRfTp0+nqKiIvXv3EhMTQ7t27XTnGDlyJAMGDKhx3nfeeafOeFasWIFCoWDOnDlcvnyZTz/9lBkzZvDDDz9gZWUFQFRUFHPmzKFz5848+uijKBQKNm7cyH333cf69esJCwur1W6bNm147LHHACguLubll1+u89zvvfcew4cPZ/z48WRnZ7Nu3Truvfdevv/+exwcHGo9ZtKkSXTt2hWA3377jd9++63G/S+++CKbNm1i7NixTJs2jZSUFL744guio6P58ssvMTc3r7MfbkV+fj6rV6+udbtGo+Ghhx7i8OHDTJw4EX9/f2JiYvj0009JTEzkgw8+uGabDz74IOPHjwcgJyeHRYsW1Xiu/3Tw4EG2bNnCtGnTsLCw4Msvv2T27Nl88803BAYGAlWJztGjR7nrrrto06YNqampfPnll0yfPp3NmzfrNbW3qKiIvn370q5dO7RaLb/88gvPP/88Dg4ODBs2DIB9+/aRnJzM2LFjcXd35/z582zYsIHY2Fg2bNiAQqGos+2zZ8/yyCOPMHDgQF566aVbju1aLly4UCvZvJYffviBmJiYW2q/evp0tbpe7+fPn+fee+/F1taW2bNnY2Zmxtdff820adNYt24dXbp0uaVz1qWwsJBvvvmGkSNHMmHCBIqKivj22291r4vg4GDdsf/3f//Hxo0bGTBgAOPHj6eyspJDhw5x/Phx3QyCL7/8kg4dOnD77bdjZmbGzp07eeWVV9Bqtdx77701zm1paclPP/3EU089pfsdS09PJyoqCktLy3o/NyGEaUkiJ4RokQoLC8nOzqa8vJwjR46wfPlyrKysGDRoEFA1uvLrr7+iVP49cWHMmDEMHz6cb7/9lkceeQSA77//nqioKJ599llmzJihO/b+++9Hq9XWOGdISAhjxoypcduaNWvqjC8vL48tW7ZgZ2ene+z8+fPZsGED06dPR6vV8vLLL9OzZ08+/PBD3YfwyZMnc9ddd/Huu+/y0Ucf1WhTrVbj4OCgiyE7O7vWB9vU1FTef/995s+fz4MPPqi7fejQofzrX/9i/fr1NW6vrKwEIDIyUtduUlJSjUTu0KFDfPPNN7z99tuMGjVKd3vPnj2ZPXs2W7durXG7vlatWoWZmRmdOnWqcftPP/3Evn37+Pzzz+nWrZvu9g4dOvDSSy9x5MgRIiMj62yzb9++uu9TUlJYtGgR4eHhtf4fq8XExPDdd9/RuXNnAO666y7uvPNOli5dyrJlywC47bbbuPPOO2s8btCgQUyaNIlff/2Vu++++5af+5w5c2r8PGnSJHr06MGBAwd0idw999zDzJkzaxwXHh7OY489xuHDh2v0TbXU1FRmz55NUFAQ77zzDiqV6pZju5YlS5bg6+tLQUHBdY+rHk0dMGAAu3fvvun2r54+DXW/3t99913UajVffvkl3t7eANx9993ceeedvPXWW6xbt+6a7Ve/N/zz9/yfHB0d+f3337GwsNDdNnHiRIYPH87nn3/OwoULgapRz40bNzJt2jSef/553bEzZ86scY5169bpLuYATJ06lVmzZvHxxx/XSuS6detGdHQ0v//+u+51sHHjRsLCwrh06dJ14xZCNH4ytVII0SLNmDGD3r17M3DgQBYsWICtrS3Lli3TjbRZWFjoPqhVVlaSk5ODjY0Nvr6+REdH69rZtm0bzs7OTJ06tdY5rjXCcTPuvvtuXRIHcOedd+Lu7s6uXbsAOHPmDImJiYwaNYqcnByys7PJzs6muLiY3r17c/DgQV3p9mrl5eU1PkzW5bfffkOj0TB8+HBdm9nZ2bi5udG+fXv2799f43i1Wg1w3Xa3bt2Kvb09ffv2rdFmp06dsLGxqdVmRUVFjeOys7MpKyu7btwZGRmsW7eOhx9+GFtb21rn9/f3x8/Pr0ab1dNp/3n++oiIiNAlcQCenp4MHjyYPXv26JLeqz+Eq9VqcnJyaNeuHQ4ODjVeW9WqLzpU//vndNRqlZWVZGdnk5qayieffEJhYWGNkcOrz1tWVkZ2drZuxOn06dO12svJyWHWrFnY2tqyYsUKg47gnDp1iq1bt/LYY4/VuFhSly+++ILc3FweffRRg50fqvpr7969DBkyRJfEAbRq1YqRI0dy+PBhCgsLr/n46jV7GRkZ1z2PSqXS/X5oNBpyc3OpqKigc+fOtd5LFApFnc/z6veSq/8fCwoKyM7OpkePHiQnJ9dKis3NzRk1alSN6aibNm1i3Lhx141ZCNE0yIicEKJFevHFF/H19UWlUuHm5oavr2+ND5QajYbPPvuM9evXk5KSovsQDn9Pv4Sq0SdfX1/MzAz7dtq+ffsaPysUCtq3b09qaioAiYmJADz99NPXbKOgoABHR0fdzzk5ObXa/afExES0Wi1Dhw6t8/5/Ps/8/HwAbGxsrtnmhQsXKCgooHfv3nXef/ny5Ro/79mz55rHXsvSpUtp1aqVblTrn+ePi4u76fPXR1396+PjQ0lJCdnZ2bi7u1NaWsqqVavYuHEjGRkZNUZb6hqdunqk93oSExMZMWIEUPUB/qWXXtL9DFXrPpctW8aWLVtqPee6zvvggw+SkJCAq6vrDUedbtXixYvp1q0bgwYN4rXXXrvmcQUFBaxcuZIZM2bg6upq0Biys7MpKSnB19e31n3+/v5oNBrS0tLo0KFDnY8PCQnB0tKSZcuW8fLLL+umHKvV6lpThTdt2sRHH31EQkKC7uIHUGPqZ1JSEq1atarx/lKXw4cP8/7773Ps2DFKSkpq3FdQUIC9vX2N28aNG8fYsWO5dOkSiYmJZGZmMnz4cFasWHHd8wghGj9J5IQQLVJYWFiNaVf/tHLlSt577z3GjRvHf/7zHxwdHVEqlSxcuNDgH2r1UR3DU089VWONzdWuTq7Ky8vJzMykT58+121Xo9GgUChYs2ZNndPo/pmwZWVlAVx3/z2NRoOrqytvv/12nff/sxphly5dmD9/fo3b1q1bx44dO+p8fFxcHJs2beKtt96qc62dRqMhMDCwxv6BV2vTps01YzeG1157TbeWMTw8HHt7exQKBQsWLKjztVV90aFaYWEhc+fOrXWcp6cnH3/8MUVFRezcuZNFixbh4eGhmy48f/58jh49yqxZswgODsbGxgaNRsPs2bPrPG98fDxr1qxh/vz5vPnmmyxatMggz3/Pnj3s27ePr7/++obHrlmzBqVSyaxZs8jNzTXI+Q3Fzc2NF154gVdeeUU3bbFajx49dN//8MMPPPPMMwwZMoRZs2bh6uqKSqVi1apVJCcn39I5k5KSmDFjBn5+fjzzzDN4eHhgbm7Orl27+OSTT2qNwgN07NiRjh078v333xMfH8/QoUNrjPYLIZouSeSEEKIOv/76Kz179tStX6mWn5+Ps7Oz7ud27dpx/PjxOq/C18eFCxdq/KzVarlw4YKummD1VDA7O7sbJmdQVbBCrVbXmPZXl+piGV5eXnWOVPxTbGwsCoXiuse2a9eOqKgoIiMja0wLuxZnZ+daz2n79u3XPH7x4sV07NixxujTP89/9uxZevfuXa/prjfjn/9vUDVSZm1trUtYq9fBXV2psays7Jprxf550eGfVSKrWVtb6/rtjjvuIDU1lQ8++IBBgwaRl5dHVFQUc+fOrTF1r3pkty4rVqygW7duPP7447z66quMHj36lkdK/0mr1bJ48WLuuOMOwsPDr3vspUuX+Oyzz3jsscews7MzeCLn4uKCtbU1CQkJte6Lj49HqVTi4eFx3TYmTJjAHXfcwfnz53UjbW+88UaNY3799Ve8vb1ZtmxZjdff0qVLaxzXrl079uzZQ25u7jVH5X7//XfKy8tZsWIFnp6euttvND143LhxfPLJJ2RlZclInBDNiKyRE0KIOqhUqlqjFL/88kut9TBDhw4lJyeHL774olYb9Rm5+/7772usz9m6dSuZmZm6qpedO3emXbt2fPTRRxQVFdV6/D8/7G/duhWVSqUbnbmWoUOHolKpWLZsWa34tVptjVL1FRUVbNu2jbCwsFrr0q42fPhwKisr66wOWVFRoZueqY9jx46xY8cOnnjiiWsmacOHDycjI4MNGzbUuq+0tJTi4mK9z/9PR48erbHeLC0tjR07dtC3b1/dCGddI52ff/55jem79VVZWUl+fr5ue4VrFSn59NNPr9lGdfGTe+65h4iICF588UVKS0vrFdeWLVs4d+6crnLq9SxfvhxXV1cmT55cr3Nei0qlom/fvuzYsaPGFgJZWVn8/PPPdO3a9aZGrpycnOjevTt9+vShT58+NaYzV58Har4fHD9+vNYWB0OHDkWr1eqK4lyt+rF1tVVQUMB333133RhHjhxJRkYGLi4u9OzZ84bPSQjRNMiInBBC1OG2225j+fLlPPvss0RERBATE8NPP/1UoygCVBUl+f7771m0aBEnTpyga9eulJSUEBUVxZQpUxgyZIhe53d0dOSee+5h7Nixuu0H2rdvz8SJE4Gqinn//e9/mTNnDiNHjmTs2LG0bt2ajIwM9u/fj52dHStXrqS4uJgvvviCzz//HB8fnxpX7qsTmHPnznH06FEiIiJo164d8+fPZ/HixaSmpjJkyBBsbW1JSUlh+/btTJw4kVmzZrFv3z7ee+89zp07x8qVK6/7XHr06MGkSZNYtWoVZ86coW/fvpibm5OYmMjWrVv5v//7v1pVHG/Wnj176Nu373VHJceMGcMvv/zCSy+9xP79+4mMjKSyspL4+Hi2bt3Khx9+eN1ptrciMDCQWbNm1dh+AKgxFfK2227jhx9+wM7OjoCAAI4dO8a+fftuuDbqeu6991569OiBp6cnRUVF/Prrr0RHR+vWUNrZ2dG9e3c+/PBD1Go1rVu3Zu/evbX2QKuLQqHg9ddfZ8yYMSxdupSnnnqqxv1//fVXjYSnelQyJiaGc+fO1diTbs+ePUycOBE/P78bnnfPnj28/fbbNyzQUx/z589n37593HPPPdxzzz2oVCq+/vprysvLefLJJw1yjttuu41t27bxyCOPcNttt5GSksJXX31FQEBAjYsIvXr1YsyYMXz++edcuHCB/v37o9FoOHz4MD179mTq1Km6350HH3yQyZMnU1RUxDfffIOrqyuZmZnXjMHR0ZE9e/agVCqNPiothGg4ksgJIUQdHnzwQUpKSvjpp5/YsmULISEhrFq1isWLF9c4TqVSsWbNGlasWMHPP//Mtm3bcHJyIjIystamyrd6/nPnzrF69WqKioro3bs3L730Uo09xnr27MnXX3/NBx98wLp16yguLsbd3Z2wsDAmTZoEVI3MVa9Ni4uLq/UhHKoqVdrZ2REREQFUbZ3g4+PDJ598wvLly4GqdWR9+/bl9ttvB6qmeJmbm7N69Wr69+9/w+fz6quv0rlzZ7766iuWLFmCSqWibdu2jB49+pql/2+GQqHg8ccfv+4xSqWS5cuX88knn/DDDz/w22+/YW1tjZeXF9OmTbupKaQ3q3v37oSHh7N8+XIuXrxIQEAAixYtomPHjrpj/u///g+lUslPP/1EWVkZkZGRfPzxx8yePVvv83bo0IEff/yRS5cuYWNjg4+PD2+++WaNrQwWL17Ma6+9xvr169FqtfTt25c1a9bc1P+fv78/Dz74ICtWrGDkyJGEhITo7luwYEGdj/n444/Jzc2tMdXQysrqpqtPBgcHM3LkyJs6Vl8dOnTgiy++YPHixaxatQqtVktYWBhvvfWWQfaQAxg7dqxuH8o9e/YQEBDAW2+9xdatWzlw4ECNYxctWkRQUBDffvst//vf/7C3t6dz5866300/Pz+WLl3Ku+++y5tvvombmxtTpkzBxcWF55577rpx1LX/oxCiaVNoG8OqfSGEEEDVWpfp06fz3nvv6T1KdbWUlBQGDx7Mjh07alTIu9r7779PampqrbU94tYEBQVx77338uKLL5o6lEaheg2gvK6EEMI4ZI2cEEIIIYQQQjQxMrVSCCGaMRsbG0aNGnXdfd6CgoJo1apVA0YlWoLAwEBThyCEEM2aJHJCCNGMubi4XHP/tmrX2vxbiPqYOXOmqUMQQohmTdbICSGEEEIIIUQTI2vkhBBCCCGEEKKJkUROCCGEEEIIIZoYWSPXiBw9ehStVou5ubmpQxFCCCGEEELUg1qtRqFQ6PaCNDQZkWtEtFotjWHJolarpby8vFHE0hxJ/xqX9K/xSR8bl/SvcUn/Gpf0r3FJ/xqXofvX2J/tZUSuEakeiQsNDTVpHMXFxZw5c4aAgIDrliwX+pH+NS7pX+OTPjYu6V/jkv41Lulf45L+NS5D9+/JkycNENW1yYicEEIIIYQQQjQxjSqRu3DhAi+++CJjxowhJCSEkSNH1nncN998w7BhwwgNDWX06NHs3Lmz1jEFBQU899xz9OjRg4iICObNm8elS5dqHXfkyBEmTZpEWFgYgwYNYvXq1bWGQLVaLatXr+a2224jLCyMSZMmcezYMYM8ZyGEEEIIIYS4VY0qkTt//jy7du2iffv2+Pv713nM5s2beeGFFxg+fDhr1qwhPDycRx99tFZiNX/+fPbu3cvLL7/M22+/TUJCAnPmzKGiokJ3zIULF5g1axbu7u6sWrWK++67j6VLl/LRRx/VaGvNmjUsXbqUGTNmsGrVKtzd3Zk5cybJyckG7wMhhBBCCCGEuJFGtUbu9ttvZ8iQIQA888wznDp1qtYxS5cu5a677mL+/PkA9OrVi5iYGJYvX86aNWuAquqPe/bsYe3atfTr1w8AX19fRowYwbZt2xgxYgQAa9euxdnZmXfeeQcLCwt69+5NdnY2K1euZNq0aVhYWFBWVsaqVauYOXMmM2bMAKBr167ceeedrF27lpdfftm4nSKEEEIIIYQQ/9CoRuSUyuuHk5ycTGJiIsOHD69x+4gRI4iKiqK8vByA3bt34+DgQN++fXXH+Pn5ERwczO7du3W37d69m8GDB2NhYVGjrfz8fI4ePQpUTb0sLCyscU4LCwvuuOOOGm0JIYQQQgghRENpVIncjcTHxwNVo2tX8/f3R61W66Y6xsfH4+vri0KhqHGcn5+fro3i4mLS0tLw8/OrdYxCodAdV/31n8f5+/tz8eJFSktLDfTshBBCCCGEEOLmNKqplTeSl5cHgIODQ43bq3+uvj8/Px97e/taj3d0dNRN1ywoKKizLQsLC6ytrWu0ZWFhgaWlZa1zarVa8vLysLKyqu9T09FqtRQXFxusPX2UlJTU+CoMS/rXuKR/jU/62Likf41L+te4pH+NS/rXuAzdv1qtttbAkiE1qUSuJVCr1Zw5c8bUYQCQmJho6hCaNelf45L+NT7pY+OS/jUu6V/jkv41Lulf4zJk/169hMvQmlQi5+joCFSNprm7u+tuz8/Pr3G/g4MD6enptR6fl5enO6Z6xK56ZK5aeXk5JSUlNdoqLy+nrKysxqhcfn4+CoVCd5yhmJubExAQYNA2b1VJSQmJiYn4+PhgbW1t0liaI+lf45L+Nb6m1seXckpwc7RCqTTeVVFDamr929RI/xqX9K9xSf8al6H7NzY21gBRXVuTSuSq16nFx8fXWLMWHx+Pubk53t7euuOioqJqDWcmJCQQGBgIgI2NDR4eHro1cFcfo9Vqde1Xf01ISKBjx441zunp6WnQaZUACoXCIDvJG4K1tXWjiaU5kv41Lulf42sKfbxt/wXe33CMO3q0Y96kCFOHc0uaQv82ZdK/xiX9a1zSv8ZlqP415rRKaGLFTry9vfHx8WHr1q01bt+yZQu9e/fWDV0OGDCAvLw8oqKidMckJCQQHR3NgAEDdLcNGDCAHTt2oFara7Tl4OBARETVH/zIyEjs7Oz45ZdfdMeo1Wq2bdtWoy0hhBCNS05BKR/9WLUu+rcDSZyMzTJxREIIIYThNKoRuZKSEnbt2gVAamoqhYWFuqStR48euLi4MHfuXJ544gnatWtHz5492bJlCydOnGDdunW6diIiIujXrx/PPfccTz/9NJaWlixZsoSgoCCGDh2qO27WrFn89NNPPP7440yZMoWYmBjWrl3LggULdEmhpaUlDzzwAO+//z4uLi4EBgby5Zdfkpuby6xZsxqwd4QQQtyKj348TVFpBSqlgkqNlhUbj/PeY4MwN2tS1zCFEEKIOjWqRO7y5cv85z//qXFb9c+fffYZPXv2ZOTIkZSUlLBmzRpWr16Nr68vy5Yt042gVXv33XdZtGgRL774IhUVFfTr14/nn38eM7O/n3L79u1Zu3Ytb7zxBvfffz8uLi7MmzePmTNn1mhrzpw5aLVaPvroI7KzswkODmbt2rW6qZxCCCEal+PnM/njSAoKBbw8pxeLvzhCckYh3++KZcLgQFOHJ4QQQtRbo0rkvLy8OHfu3A2PmzBhAhMmTLjuMfb29ixcuJCFCxde97jIyEg2bNhw3WMUCgUPPPAADzzwwA1jE0IIYVrqikpWfHccgLv6+BIe2Ip/j+rEki+P8NVvMQyI8KK1i6wtEUII0bTJ/BIhhBDNysadsaRmFuFsb8nU4cEADOrqRWd/V8rVlazedNLEEQohhBD1J4mcEEKIZiMtq4ivt8cAMHtMZ2ytzYGqmRUPjQ1DpVRwIDqdv06lmTJMIYQQot4kkRNCCNEsaLVaVm46gbpCQ3gHd/qHt61xf7s2Dvzrtqp9Old/f5LSsgpThCmEEEIYhCRyQgghmoW9Jy5y5OwlzFRKHhwXVuf+PZPuCKSVszWZOSV89duN12QLIYQQjZUkckIIIZq84lI1a76v2jNuwuAOtHW3q/M4KwszHvhXGADf74rjQlp+g8UohBBCGJIkckIIIZq8L7aeJTu/FA83W8bf3uG6x/bo1Iaendpc2VvuBFqttoGiFEIIIQxHEjkhhBBNWlxKLj/viQfgwbFhWJirbviY+/8ViqWFitPxl9lxMNnYIQohhBAGJ4mcEEKIJqtSo+WD746j0UL/8LZEBrW6qce1crZhyh1BAHz882nyi8qNGaYQQghhcHptCB4cHHzDYxQKBdHR0fo0L4QQQtyUbX8lEpOUi42VGbNGd7qlx44Z6M/vh5NJSi/gsy3RPDoh3DhBCiGEEEZwU4ncrl27iImJYeLEiTg6OqLValEoFPTv35+wsDBjxyiEEELUklNQyqdbzgAw9c5gXB2tb+nxZiolD4/rwjPL9/DrXxcY0r0dHX1cjBGqEEIIYXA3lci1bt2aDz/8kE2bNvHjjz+yYcMG3n77bXbv3o21tTWPPfYY7du3N3asQgghhM5HP52mqERNgJcjI/r66tVGJz9XBnf3ZsfBZD747jhL5g9EpZJVB0IIIRq/m/pr1bFjR1577TXi4+OJiYkhLCyMzz77jFWrVnHhwgXuuusuXnnlFbKzs40drxBCCMGJ2Ez+OJyCQgEPj++CSll7z7ib9e+RnbCzNifhYj4/7UkwYJRCCCGE8dz0Zce8vDwALC0tdbcNHDiQ77//ntdff53du3czePBgli5dSlFRkeEjFUIIIQB1RSUffHsCgOG9fejg7Vyv9hztLJkxMgSA9b+eISu3pN4xCiGEEMZ2U4nc9u3befjhhxkyZAj+/v617h8zZgxbt25l/vz5fPnll9xxxx18/vnnBg9WCCGE2PhHLKmZhTjZWzJtRIhB2ryjR3s6tnempKySD388ZZA2hRBCCGO6qTVy7du3Z/ny5YSHhwMwffr0ax7r4eFBdHQ0CxcuZNq0aQYJUgghhABIv1zEht9iAJg1ujN21uYGaVepVPDw+C7Mf+cP9h6/yJGzl4jseHNbGQghhBCmcFMjch06dNAlcQBarfaa/2xtbenevTvdunUzVsxCCCFaIK1Wy4qNJyiv0NClgxsDI9oatH1fT0dG9vcDYOXGE5SpKw3avhBCCGFIeu0jJ9MmhRBCNLR9J9I4cvYSZiolD43rgkKhf4GTa7l3WEf2HLtI2uUivt1xnnvv7GjwcwghhBCGIDWWhRBCNHrFpWpWf38SgPG3d6Ctu51RzmNjZc6cuzsD8O3v50nNLDTKeYQQQoj60mtE7uDBgzd1XPfu3fVpXgghhKjhi1/Pkp1fioerLRMGdzDqufqGeRIZ1Ioj5y6x8rsTvPpAb6OM/gkhhBD1oVciN23aNN0fNa1WC1Djj5xWq0WhUHDmzBkDhCiEEKIlu5CWz89/xgPw4NgwLMxVRj2fQqHggbGhPPrWTo6dz+T4+UzCA6XwiRBCiMZFr0TO1dWVy5cvM3DgQKZNm4aFhYWh4xJCCCHQarV8+MMpNFroHerRYJUkPd3s6NvFkz8Op3AmIVsSOSGEEI2OXoncb7/9xkcffcTHH39MTEwM8+bN4+6775apJ0IIIQzqYHQGx85nYqZSMnNUpwY9dwcvJ/44nEJcal6DnlcIIYS4GXoVO7GxseHRRx/lt99+Y/Dgwbz44ouMHj2aP/74w8DhCSGEaKnUFRrWXtmc++6B/rRxtW3Q8/u1dQQgLiW3Qc8rhBBC3Ix6Va10cXHh+eefZ8uWLQQGBvLQQw8xdepUjh8/bqj4hBBCtFCb9yZwMasIJ3tLoxc4qUt1IpeVV0peYVmDn18IIYS4HoNsP+Dt7c3ixYvZuHEjlpaWTJ48mblz5xqiaSGEEC1QXmEZX207C8C04cHYWJk3eAw2VuZ4ulWNAsr0SiGEEI2NXmvkOnbseM31cNVVLLdv365/VEIIIVq09b+epai0Aj9PRwZ3b2eyOPy9nLiYVURcSi6RQVLwRAghROOhVyL3yCOPSGETIYQQRnEhLZ+tUYkAzB7TGZXSdH9v/Ns68uexVBmRE0LoqCs0FBaXU6aupLWLjXwmFiajVyIn0yaFEEIYg1ar5cMf/95uIDTAzaTxVK+Ti0+RRE6I5qhMXUluQRkFReXkF5dTUFROQXE5+UXltW8rVlNQVE5JWYXu8R3bO7NgSiSe7nYmfBaipdIrkbuRvLw8YmJidD87OjoSGBhojFMJIYRoQDkFpfy0O442NmqjtH/oTAbHYqq2G/j3yIbdbqAu1Ylc2uUiikrU2Fo3/Fo9IUT9VGq0ZOYUk5pZSGpmIRczi3TfZ+WWcGVV0C1RKEChUHD2Qg5zF//BjLtCuKuvL0oTziAQLY9RErkTJ05w//3369bL9e/fnzVr1hjjVEIIIRqIuqKS19bu53xyLnZWSjp0KMbXxsZg7VdU/r3dwJgBfni4Nex2A3VxtLPE3dmazJwS4i/mEepv2hFCIUTdtFoteYXlVxK1Ql2ilppZRFpWERWVmms+1txMib2NBQ62FtjbWGBva677+e/bLHC48tXexgJba3Mu55Ww9OujHD+fxervT/LXqTT+MymCVi6Ge18U4noMXuzkamfPntWneSFEC6fVaknOKMDd2QZrS6NcbxJ6WPPDKc4n5wJQWKrh9U+O8Na8ATg7WBmk/c17E0jNLMLJzpKJQxrPLA7/to5k5pQQlyKJnBCN0Xe/n+eb389TVHLtmQJmKiWe7ra0dbfD063qa9tWdrR1t8PB1kKvdW6tnG149f4+/LIvgY83R3MiNotH397JnDGdGdKjnaydE0an1yeke+6557ovzosXL8rm4EKIW1ZUouaPw8n8EpXIhfQC/DwdeWtefyzMVaYOrcX7/VAyv+xLRKGAB+4O4att58jIKeGlNVEsfLgfdvWccphXWMaX284BMNVE2w1ci19bJ/46lU5caq6pQxFC/EPUyTQ+2RwNVE13dHeyrkrS3O3w1H21xd3ZxiiFk5RKBXf18yMiqBXvfnWUM4nZLN1wjH0n05g7MRwXA13oEqIueiVyL7744nXv//PPPyWRE0LctNiUXLZGJbLrSAql5ZW62+Mv5vHp5mjm3B1qwuhEwsU8ln97HIDJdwQxKLIt5hXZfLYzm4SL+fz3o/28cn9vLOuRcH+57RxFJWp8PR0Y0sN02w3Uxd/rSsETqVwpRKNyKaeYpV8fBWB0fz+m3xVSr/eh+vB0t2PRI/34YVcsn/9ylkNnMnjkf7/z0LgwBkR4Gew8Wn0W9IlmS+YsCSFMorS8gj+PpvJLVKJuuh6Ad2t7RvTxwcHWgrfWHebHP+OJCGpFt+DWpgu2BSssUbPok4OUqyuJ7NiKyXcEUVpagqu9Gc9Nj+SVjw5xOv4yb31+iGfv645Kpbzlc1xIz+eXRrLdQF38rxQ8SckooLS8AisL+dMphKlVVGp4e91hCkvUBLZzYsbITpib3fr7jyGplArGDupA1+DWLPnyCHEpeby17jBRJ9N4cGwYjnaWt9xm9VKD4+ezOH4+k5NxWThYK3jDrwMGXKIsmij5aySEaFBJ6fls/esCvx9Moqi0qoSzmUpJ3zBPhvfxIcTXRTd1++yFHH76M573vjrK0iduw9lepqg0JI1Gy7tfHiHtchGtnK15/J6uNSqy+XjY8/zMnry0Oor9p9N5/5tj/GdSxC2tC9Fqtaz94RQajZbeoR6EBbgb46nUi4uDFU72luQWlJGYlk/H9i6mDkmIFu+LrWc5k5iNrZUZT07tZvIk7mrt2zjw9rwBbNgew9fbY9hz/CKn4i/z6Pgu9OzsccPHZ+aUcPx8JsdjMzlxPpPs/LIa9xeXwsebz/LE1B7GegqiiZBETghhdOqKSvadSOOXqEROx1/W3e7hasudvdszuHu7Oq9UzrgrhJOxWSSm5fPeV0d5aXYvWTzegL7beZ79p9MxUyl55r7uONha1Dom1N+Np6Z1Y9EnB9hxMBkHW0tmjrr5bQMOn73E0ZhMzFSKRrHdQF0UCgV+bR05cvYScSl5ksiJJqmyUkNJWQXFZRWUlFVQUlrz+5Kyv/8Vl6pp7WLLqP5+jSpBqnbk3CW+/f08AHMnRtDG1fQVbv/JTKXknmEd6RHShne+PEJyRgH//fgAg7t7M2dMaI2tTAqKyzkRWzXiduJ8JqmZRTXasjBTEuLrSlgHN+yslKzYdJpdR9PoFpLCbZGGm7Ypmh69ErkHH3zwuvfn5OToFYwQonm5lF3Mln0JbD+YRF5hOVC1MLxnpzbc2duH8A7u191zx8JcxRP3duWxd3dx+OwlftoTz+j+/g0Vfot2PCaTdb+cAeDBsaF08Ha+5rG9Onswd2I47319jE1/xOJoa8G42zvc8BwVlRo+/KFqu4HR/f0bxXYD1+KvS+RyTR2KEDdUqdGydV8Cm/clkF9UTklpBeUV1y6/fy2JaXksmBLZqC6gZeeXsmT9EQCG9/ahbxdPE0d0fQHeTry7YCDrtp7l+12x7DiYzPHzWUwZGsTFzEKOn88kLjWvxl52SgV08HYmrIMbXTq4E+zjoiv6VVxczOmYJHadKuCDb4/Tsb1zo0xkRcPQK5G7erPva/HwuPHQsRCiedJqtew4mMTKTScpu1K8xNXRimG9fBjasx2ujtY33VZ7DwdmjurEyk0n+finaEL93fD1dDRW6ALIyi3hrS8OodHCkO7tGNqz/Q0fM6RHe/KLyvn452g+2RyNg60Fd9zgcVv2JZCaWYijnUWj2m6gLv5eTkBVAR4hGrO4lFyWf3u8xtrjq5mbKbG2NKv5z6rqq82V75UKBT/+Gc/Owyl4uNoyZVjHhn0S11Cp0bL4i8PkFpbh4+HArDGdTR3STbEwVzFzVCd6dmrDu18dIf1yMe9vOFbjGO/WdnTp4E6XDu509ne7biXgAZ0dSM9XcS4pl7fWHeLNR/tjpsf6ZNH06ZXI/f7774aOQwjRTBSVqPngu+PsPpoKQLCPC2MHBdA9uLVehTAARvT15fC5SxyMzuCtdYdZsmCgySqTNXfqCg1vfHaQvMJy/DwdeXBc2E1fjR87qAN5heVs/COWZd8cw87Ggt6hdV/Uyy8q58tfr2w3cGdwjWlGjVF1wZMLafmoKzSNcrqZaNlKyir4YutZfvozDo0WbKzMmDY8mM7+bjWStpt97bZ1t2P5t8dZv+0crV1tub2bt5GfwY19uyOGE7FZWFqoeGpatyb3d6CTnytLHx/Eul/OcCI2C7+2joQHuhMW4HZLFzhVSgVzJ3Tm6Q/2E5OUy/pfzzJ9RIgRIxeNldH+EhmzPOqOHTuYMGECERER9OvXj//85z8kJyfXOu6bb75h2LBhhIaGMnr0aHbu3FnrmIKCAp577jl69OhBREQE8+bN49KlS7WOO3LkCJMmTSIsLIxBgwaxevVqKQErxD/EJOXwn3f+YPfRVJRKBdNHBLPokX706uyhdxIHVWuU/jMpAmd7S5IzCvjox1MGjFpc7aMfT3HuQg621uY8O6P7LX9QmjEyhCHd26HRwlvrDnEyNqvO477cdpbCEjU+Hg43HLlrDFq72GBrbU5FpZak9HxThyNEDX+dSuPh//3OD7urkrj+4W1Z8fRgRvbzw8fDgdYuNjjYWtzSBYg7e/swblAAAO9vOHrN3+WGcjr+Mut/PQvAQ2PD8G5tb9J49GVtacacu0N5/4lBLJgSyaCu3reUxFVzd7Jm7oRwAL79/TzHz2caOFLRFOj1yergwYPXvf/cuXNMmjRJr4BuZP/+/Tz66KMEBASwfPlynnvuOc6ePcvMmTMpLS3VHbd582ZeeOEFhg8fzpo1awgPD+fRRx/l2LFjNdqbP38+e/fu5eWXX+btt98mISGBOXPmUFFRoTvmwoULzJo1C3d3d1atWsV9993H0qVL+eijj4zyHIVoajQaLd/9fp6n3v+TjOxiWjlb8+Yj/ZgwONBgpeQd7SyZPyUSgC37EjlwOt0g7Yq//XE4mZ/3JgDw2D2Req27UCgUPDqhCz07tUFdoeG1j/bXWleWlJ7Pln2JAMy5u/FtN1AXhUKhG5WLk/3kRCORmVPCfz/az+sfHyArt4TWLja8PKcXT03rZpCNqKePCKFvF08qKrW8/skBkjMKDBD1rcsrLOOtdVXTvW/v5s3g7o1rr0lT6dvFk2G92qPVwjvrD5NXWHbjB4lmRa9Ebvbs2fz222+1bi8vL2fJkiWMGzeOoqKiOh5Zf5s3b8bT05OFCxfSp08fRowYwSuvvEJSUhKnTv19lX7p0qXcddddzJ8/n169evHqq68SGhrK8uXLdcccPXqUPXv28PrrrzNixAgGDx7Me++9x7lz59i2bZvuuLVr1+Ls7Mw777xD7969mTFjBjNnzmTlypWUl5cb5XkK0VTk5Jfy0uooPtkcTaVGS78unrz3+CA6+hi+sl9kUCvuHlhV7OS9r4+SnV96g0eIm3UhLZ9lVzb9njgkkB4hbfRuS6VS8uS0bnTyc6WkrIKX1/zFxcxC3f1rfzqNRqOlV+c2jXK7gWvxaysbg4vGobJSw/e7Ynn4fzvYfzodlVLBhMEdWPbkILp2NNyem0qlggVTIunY3pmiEjWvfPgXuQUNmyxotVre+/ool/NKaetux4Njwxr0/I3d7NGd8WplR3Z+GUu/PiazxVoYvRK50aNHM3/+fNavX6+77eDBg4wePZq1a9cyZ84cNm3aZLAgr1ZRUYGtrW2NNRv29lXD69Uv3uTkZBITExk+fHiNx44YMYKoqChd8rV7924cHBzo27ev7hg/Pz+Cg4PZvXu37rbdu3czePBgLCwsarSVn5/P0aNHDf8khWgiDp/NYO7inRw7n4mFuYq5E8N5alq36y7Srq/pI4Lx83Qkv6icJV8eQaORP1r1VVyqZtGnBygrryQ80J17DFDYwNJcxQsze+Ln6UhuYRkvrI7icl4Jh85kcOTspartBm5hm4LGoLrgiVSuFKYUk5TDY+/uZu2PpyktryTYx4X3Hr+N6SNCjLJZvaW5iudn9qSNqw0Z2cX896P9lKkrDX6ea/lhdzwHozMwN1Py9PRuWFvKzllXs7I046lp3TBTKTkQnc7mK7MqRMugVyL32muv8cADD/Daa6+xePFiXnjhBaZPn46joyObNm3iP//5T42kx5DGjh1LXFwcX3zxBQUFBSQnJ/POO+8QEhJCZGTVtKv4+HgAfH19azzW398ftVqtW08XHx+Pr69vrYX8fn5+ujaKi4tJS0vDz8+v1jEKhUJ3nBAtibpCw9ofT/Hymr/IKyzHx8OBdxcMZGjP9kYvU21upuKJqV2xMFdxLCaTH3bHGfV8N6OiUsMv+xL440gKxaVqU4dzS7RaLe9+dZTUzCLcnKx54t6uBpvqaGttzsv398LD1ZZL2cW8tDpKt93AqP7+eLrZGeQ8DaV6amX8xXwq5QKCaGBFJWpWbjzBE0t3E38xDztrcx6dEM4bj/SjfRsHo57b0c6Sl2b3ws7anHNJOSz+4nCDXESLScrh082nAZg9prNULL4GX09H/j2qqtjJRz+dJkGq67YYel/WmDdvHq1bt+bVV19Fo9Hw9NNPc9999xn9Q1y3bt1YtmwZjz/+OK+++ioAwcHBfPjhh6hUVYvy8/KqXsAODjXf2Kp/rr4/Pz9fN5p3NUdHR900zYKCgjrbsrCwwNraWteWoWi1WoqLiw3a5q0qKSmp8VUYVlPv37TLRSzdcJL4i1W/G8N6ejN1WAcszFUN9tp1tVdx3/BA1vx4hk+3RNPByw4/z6rf0Ybu39zCMt79+gRnEnOBqtLekUFu9A1tQ0Sgm27vn8bqxz2JRJ1MQ6VSsGBSKObKyhv+P95KH1uq4Nnp4by45iAX0q+8n9qaM7qvl8nf626Vs60SS3MlZepK4pIy8WplnES0qb9HNHZNrX+1Wi1/nb7Ep1vOklNQNaOofxcPpt0ZiKOdBaWlDfM8XOxUPH5PF17/5DBRJ9NY8/1xpt1Ze9sQQ/VvcamaNz87SEWllp4hrRjYpVWTe88whmv17+DINhyOTudITBZvfnaQRQ/2xNKicf/9aYwM/f6g1WqNmhvVa3x60qRJuLm58fjjj/PXX38xZcoULC0tDRVbnY4cOcJTTz3FxIkTue2228jNzeWDDz7g/vvvZ/369VhZ1X9xrymp1WrOnDlj6jAASExMNHUIzVpT7N/jCUVsPphLeYUWawslY3o509FLS1zsjfeWNDRPWy0dvaw4m1LK218c5oE7W2FxVUW2hujf5KwyNvx5mYISDRZmCuysVWQXVLD/9CX2n76EhZmCIC9rOre3xr+NFWaqxlXUIyGjlPW/V1WiuzPSEXXBRc6cuXjTj7+VPp7c34mPt2dSptYyIMSWCwmxtxpuo9DK0YzkrHL2HjpHmK+NUc/VFN8jmpKm0L8ajZYNey5zNqVqPbCLvRkjuzvh10bFxeQ4bv631TAUwOiezmzcl83Pey+gLc+je4e6L2jUp3+1Wi3f7s3mUk4JTrYqbgsx4+zZs3q31xzV1b+DO5sTk6QkNbOI977cz6gezg0fWDNhyPcHY81SBD0TuWeffbbGzz4+PuzatYuJEycSElI1tKtQKFi4cGH9I/yH//73v/Tq1YtnnnlGd1t4eDi33XYbP/zwA5MmTcLRsWrovaCgAHf3vxfS5+dXlYyuvt/BwYH09NqV7/Ly8nTHVI/YVY/MVSsvL6ekpER3nKGYm5sTEBBg0DZvVUlJCYmJifj4+GBtfeslccX1NcX+LSmrYO1PZ/nzeA4AIT7OPDq+M66Opr1w8oRPOU8t/4vL+WXsj1dw/5jgBulfrVbL9kOpfLIjlcpKLZ5utjxxTxc83WxITCtg38kM9p1MJyuvlJOJxZxMLMbW2oweIa3oE9qGTj7O9dqOwRCy80tZ8uN+tNorV/dHdbrpq4b69HEw0CGgkISLBfTr0sboszeMJSROQXJWMmUKO4KDg4xyjqb4HtGUNKX+PR57mbMpqahUCu7u78vdA3xMPsofHAxm1vFs2BHHlkO5hHb0ISLw789ahujf3w6mcDopFZVSwRP3dqWDt0yprHaj/v2PgwcLPz3C4dgiBnbzp2cnwxW/aQkM/f4QG2vci5Z6JXL79++vdZuHhwcFBQW6+4z1RzouLo7BgwfXuK1NmzY4OzuTlJQEoFvPFh8fX2NtW3x8PObm5nh7e+uOi4qKqjXsmZCQQGBg1XQBGxsbPDw8aq2FS0hIQKvV1lo7V18KhQIbG+Ne5b1Z1tbWjSaW5qip9G9qZiGvfHiAtKwilAqYMqyjQbcVqA8bGxseu6crL6zax45DqfTo5El4gBNgvP4tV1eycuMJfjtQ9X7TO9SD+ZMjsLGqKvDSKcCWTgFtmH13GOcu5LD7WCp7jqWSU1DGzsMX2Xn4Io52FvQN82RAhBfBPi4oG6AvNRotl3KKSUov4EJ6PruPpurWN86bHKlXkYRb7eNAHxsCfVrd8nkak44+rvy6P5mkjGKj//42lfeIpqop9G9KZgoAfUM9mTEq1MTR/G3q8E5czi9nx8Fk3v36JG880k9XDKiavv2bmJbPZ1vOAVXbH3QJ8jBEyM3Otfq3V6gNY2/L57udsaz+4QydA9rg7ty4L1g0RoZ6fzD2RUu9Ernff//d0HHcNE9PT6Kjo2vclpqaSk5ODm3btgXA29sbHx8ftm7dypAhQ3THbdmyhd69e+uGOAcMGMAHH3xAVFQUffr0AaoStOjoaGbPnq173IABA9ixYwdPPvkk5ubmurYcHByIiIgw6vMVwtTW/XKGtKwi3J2rCmGE+LqaOqQaunRwZ+xtAXy3M5b3Nxzjf4/0Mtq5LuUUs+jTg8Qm56JUwLQRIYwbFFDnG7VCoaCjjwsdfVyYNboz0fGX2X0slb3HL5JXWM6WfYls2ZeIq6MVfcM88Wplh6OdJU72V/7ZWWJtaXbLfwS0Wi3Z+aVcSKtK2KoTt+SMAkrLa1aas7Ey49n7uhul0l1z5dfWCYD41Fyjr30QIvZKhdR/JkmmplAoeGR8OFm5JRw/n8Wra/ez+D8DcHOqX8JQWlbBm58dpLxCQ9eOf283I27N1OHBnIjN4nxyLovXH+b1h/o2iouvwvCa3F/vyZMns3DhQv773/9y++23k5uby4oVK3B1da2x3cDcuXN54oknaNeuHT179mTLli2cOHGCdevW6Y6JiIigX79+PPfcczz99NNYWlqyZMkSgoKCGDp0qO64WbNm8dNPP/H4448zZcoUYmJiWLt2LQsWLDDqvFchGoOzF6qmUy6YHNnokrhq994ZzPHYLGKTc1n+3SnG9TT8VfbjMZn8b90h8ovKsbex4MmpXYkIurnRJZVSQWiAG6EBbjzwr1COn8/kz2OpRJ1M43JeKT/+WXf1WwtzFU52FlcSOyscq7+3t8TZzgpHewu0WkhKLyApo4ALafkkpedTVFpRZ3tmKiXere1o38aBdm3s6dvFs8lVjjQ179b2mKmUFJVWkJFdrNem6ULcrLiUqoJq/l6Nb2qhuZmSZ+7rwVPv/0lyRgGvfPgXbz7ar15trtx0gpRLhbg4WLFgSmSDzFZojsxUSp6c2o3/vLOT0/GX2bA9hilD6z8VXKvVUlJWQXFpBcWl6itfKyjSfa+mqFRNyT9u8/V0ZOYtTN8XN6/eiVxhYSGFhYVoNJpa93l6eta3+VqmT5+OhYUFX375Jd999x22traEh4fz7rvv4uz896LOkSNHUlJSwpo1a1i9ejW+vr4sW7as1gjau+++y6JFi3jxxRepqKigX79+PP/885iZ/d017du3Z+3atbzxxhvcf//9uLi4MG/ePGbOnGnw5ydEY5KTX0pWbgkKReP8IFHN3EzJk/d25T/v/MHphBzaOFTSyUBblGm1Wjb9Ecunm6PRaKv64dn7etDaRb9k0UylpGvH1nTt2JqHx1Vy5Nwljpy7RHZeKXmFZeQWlpFbUEZpeSXl6kou5ZRwKefWqmcplQrautvSro0D7Vvb087DgfZt7PFwtTX52rymztxMiY+HPbEpecSl5EkiJ4ymsLicjOyqKo3VW180NnbW5rw8uxePL91NYlo+b35+iCcm33gKaHGpmuSMApIzCkjKKLzytYBL2cUoFfDE1K442hm3eF5z5+Fmy0PjuvDO+iN8te0sXTq43fTFWK1WS2ZOCeeScohJyuHchRySMgooLlWjz37jx89n0T2kNWEB7jc+WNwSvRO59evX88knn+j2ZKuLMaovKhQKpkyZwpQpU2547IQJE5gwYcJ1j7G3t2fhwoU3LMwSGRnJhg0bbilWIZq688m5AHi1stetAWusPN3teOBfobz39TF2nsjHxi6GbiGehPi6YKXnBrLFpWqWbjjG3uNVteEGd/fmoXFdsDRQsQELcxW9OnvQq3PtNSClZRVVSd2VxC63oKwq0SsoI6fw7581Gi3ere1p18ae9m0caO/hQFt3W8zNpOy0sfh7OVUlcqm59O1i+AuWQsDfo3FtXG2ws2m8s39audjwwsyePPvBXo6cvcTan8/Sr0PVfflF5bqErTpZS84o4HJeaZ1tKRUwY2QnQv3dGvAZNF+Dunpz5Nwl/jicwttfHGbpY7fV+VoqKlFzPjmnKnG7kEtMcg65BWXXbFepVGBrZYaNlTk2V321tTLH+srX6tuPnL2k26hcEjnD0+vTzZdffsmrr75Kv379GDduHEuWLGHGjBlYWlqyceNG3NzcmDZtmqFjFUI0sJjkqmmVge2cTBvITRrcvR0HTqcRdSqDn/Ze4Ke9FzBTKQhq70KXDu6EBbgR1N4Zs5sYlUrNLOT1jw+QnFGAmUrBnLtDGd7bp8GmhlhZmtHG0kxGfBohvyujI9UftIUwhrjUXAD8r6zLbMwC2znz5NSuLPzkADsOpRIdb07xj5nkFZVf8zEuDla0a22PV2s72rW2x/vKPxmJM6yHxoZxLjGHtMtFLPv2OE/e25XEtPyqkbYrI24plwprjbSplAp82zoS1M6ZwHbO+Ld1xMHWAmsrMyzNVTf9t7CznysHotP561Q6Wbkl9V5HKWrSK5Fbt24d/fr148MPPyQnJ4clS5YwcOBAevfuzezZsxk3bhy5ubkGDlUI0dCqR+Q6eDeNvWgUCgVzx3fG00HN5VIrTifkkJlTwun4y5yOv8z6X8HKQkUnP1e6dHCnSwd3fDwcaq3D2H8qjXe+PEJxaQUuDpY8M70Hwb4uJnpWorGpnuYWJwVPhBE15vVxdenV2YPZozuz5odTpGWrdbe3crbWJWnere2vJG/22Fk37lkezYWNlTlPTO3KU+//yd7jFzlwOh11Re3lUK1cbAhq50xQe2eC2jnj19bRIFtdtPdwoLO/K6fiLrM1KpGpw4Pr3ab4m16JXFJSEvfccw+AroqjWl31S2tvb8/48eNZv369rCETognTarWcT6oakevg7WTaYG6BSqUk1MeG4OBgrK2tSb9czPHzmRw/n8mJ2Czyi8o5fPYSh89eAsDB1oLQADe6BLgR1sGdnYeT+fq3qg3OQ3xdeGZ6d5wdTLtfnmhcfDwdUSoV5BWWk51fiqujXGEWhtdYK1Zez+gB/jjaqIhNSKJHeAcC2rljrefUdmE4ge2cmTY8mE82R6Ou0GBjZUagtzOBV5K2wHbOONkbbyT0rr6+nIq7zK/7LzDpjiDMzWSttqHo9dtlb29PZWVVGWs7O7uqD0tXbaxta2tLVlaWYSIUQphERnYxBcVqzFRKfD0dTB2OXhQKBR5utni42XJnbx80Gi0X0vOvJHZZnI6vSuz2Hr+oWwdXbVR/P2aO6nRT0zBFy2JprsK7lR0X0guIS8mTRE4YXHGpmotZRUDjLXRyLd1DWmGnuIx/W0dJ4hqRsYMC6OjjgoOtBW3d7Rq0Imivzh64OFiRnV/KvhMXGRjp1WDnbu70+g3r0KEDZ8+e1f3cpUsXvvzySwYOHIhGo+Hrr7/Gx8fHUDEKIUzgfFIuAL6eDs2mcIZSqcDX0xFfT0fuHhhARaWG80m5HI+tGrE7m5iDmUrBw+O7MKirt6nDFY2Yv5fTlUQulx6d2pg6HNHMxKdWTat0c7KWNWPCIBQKBZ38TLOFkJlKyZ292rN+2zk2702QRM6A9ErkRo8ezVdffUV5eTkWFhbMnTuXf//739x2221VjZqZ8f777xsyTiFEA/u70EnTWB+nDzOVkmBfF4J9XZh8RxBl6kpUSoWMwokb8mvryO+HkolLlYInwvCqX1cBTWR9nBA3Mqy3D19vj+FMYjbxqXm6olGifvRK5MaNG8e4ceN0P3ft2pXNmzezY8cOzMzM6Nu3L76+vgYLUgjR8P4udOJk0jgakqG2FRDN398FTySRE4bXFNfHCXE9Lg5W9Anz5M9jqWzem8DcieGmDqlZMNhlZ29vb2bMmMHUqVMliROiiaus1Og+SLSkRE6Im1V9NTkrt4S8wmvvtySEPnQVK2XUQjQjd/Wtyg/+OJJCYfG1t6YQN0/vRK6srIzo6GiKi4sBKCws5KuvvuKzzz4jLS3NYAEKIRpe8qVCysorsbY0o20re1OHI0SjY2Nljqdb1R5/MionDKm0rILUSwUABMiInGhGQnxd8PFwoFxdyfaDyaYOp1nQK5GLiYlh8ODBjBs3jmHDhpGQkMDkyZN5+eWXWbhwISNHjuT8+fOGjlUI0UCqtx0I8HJC1YCVrYRoSv7eGDzXtIGIZiXhYj4aLbg4WMrWJ6JZUSgUjLgyKrdlXwIajfYGjxA3olcit2TJEt3XwMBAHnroIVQqFX/88QcbN27EysqKVatWGTRQIUTDiWmB6+OEuFXV65fiZUROGFBcai4Afm2dTBqHEMZwW6QXtlZmpGUVcSwm09ThNHl6JXLHjx9n6tSp3HnnnTzxxBMkJiYyY8YM2rRpQ0hICOPHj+fIkSOGjlUI0UDOt4CKlULUlxQ8EcZQvT5OplWK5sja0ozB3dsB8PPeeBNH0/TplcgVFhbSqlUrANq0aVPjK0C7du1kQ3AhmqhydSWJF/MBGZET4nqqp1amZRVRVKI2cTSiufi7YqUUOhHNU/X0ykNnMki/XGTiaJo2vRI5Nzc3XaJmbW3NnDlz8PL6e3O/vLw8bG1tDROhEKJBxV/Mo1KjxcnOEndna1OHI0Sj5WhniZtT1e9I/EUZlRP1V66uJCmjqtCJv0ytFM1UW3c7wgPd0Wpha1SiqcNp0vRK5IKCgjh+/DgAVlZWPP7443h7e+vuP3r0KJ06dTJMhEKIBnU+KReAAG8nFAopdCLE9VRPr5R1csIQEtPy0Wi0ONha4OYkhU5E81W9FcG2/UmUqytNHE3TpdeG4CtWrLju/ePHj6dt27Z6BSSEMK2Y6vVxMq1SiBvy93Ji/+l0qVwpDKL6dRTgJRfSRPPWPaQN7s7WZOaU8OexVN26OXFrDLYh+NUGDhxIQECAMZoWQhhZ9YhcByl0IsQNVa9jkoInwhCqX0eyPk40dyqlguG9fQD4eW+CaYNpwvQakbt48eJNHefp6alP80IIEyksUZOaWQhIoRMhbkb11MqUjAJKyyuwstDrz6oQwN8jcrI+TrQEQ3u2Z/2v54hNziUmKUcqZetBr784t99++00N+Z85c0af5oUQJhJ3Zf+41i42ONpZmjYYIZoAFwcrnOwsyS0sIzEtn47tXUwdkmii1BUaEtOuFDqRETnRAjjaWdI/3JOdh1PYvDdBEjk96JXIPfnkk7pErri4mGXLljFx4kR8fHwMGZsQooFVr4+T0Tghbo5CocDPy5EjZy8Rn5oniZzQW1J6PhWVGmytzWntYmPqcIRoEHf19WXn4RT+PJbKzFGd5CLyLdIrkZs1a5bu+5ycHJYtW8bw4cPp3bu3wQITQjS881dG5Dp4y1UxIW6Wf9uqRK56I2ch9KFbH9fWUQqdiBYjsJ0zAd5OxCbn8tuBJMbf3sHUITUpRil2IoRoms4nXalY2c7JtIEI0YT4ezkBEJeaa9I4RNMWe1XFSiFaCoVCwV19qrYi+GVfApUarYkjalokkRNCAJCdX0pWXilKxd8fTIUQN1Zd8ORCWj7qCo2JoxFNVXyKVKwULVP/iLbY25hzKaeEQ9Hppg6nSTFYIifTAIRo2qpH47xa22NtKZX3hLhZrV1ssLUyo6JSS3JGganDEU1QZaWGhIvViZyTaYMRooFZmqu4o0d7ADbLVgS3RK9Pa6NGjdJ9r9FUXX18/vnnsba21t2uUCj48ccf6xmeEKKhVK+PC5T1cULcEoVCgb+XEydis4hLycWvrYyoiFuTfKmQ8goN1pZmeLjamjocIRrc8D4+bNoVy9GYTFIzC2nrbmfqkJoEvRI5JyenGj+7uEiVLiGaupgrI3IdZH2cELfMr61jVSKXmscdpg5GNDnV+8f5tXVEqZQZTqLlaeNqS7fg1hyMzmDLvgTmjAk1dUhNgl6J3Oeff27oOIQQJqTVanUL7WVETohbV71OrvoDuRC3QlexUtbHiRbsrr6+HIzOYMeBJKbdGYyVLPO4ISl2IoQg/XIxBcVqzFRK2ns4mDocIZqc6nVNCWn5UnVN3LLYK1PbpWKlaMkiAlvh4WZLUWkFfxxJMXU4TUK9Ul21Wk18fDwFBQVotbX/cHXv3r0+zQshGkj1tEq/tg6Ym8n1HSFulae7HZYWKsrKK7mYWYh3a3tThySaiEqN9u9CJ7K+UrRgSqWCEX18WPvjaTbvTWBYr/ZSTPEG9ErkNBoNixcvZv369ZSWll7zuDNnzugdmBCi4UihEyHqR6VU4OfpyJnEbOJSciWREzftYmYhpeWVWFqoaNtKXjeiZRvSvR2f/3KWxLR8ohOy6eTnauqQGjW9Lr2vXLmStWvXMnr0aN588020Wi2PP/44r7zyCkFBQXTs2JG1a9caOlYhhJFIoRMh6q+6WmX1eichboau0ImnIyopdCJaODsbC26L9AJgi2xFcEN6JXKbNm1i+PDhvPLKK/Tv3x+ATp06MXHiRDZs2IBCoeCvv/4yaKBCCOOorNToPnh2kBE5IfRWPS0uXhI5cQt0hU5kWqUQQFXRE4C9Jy6SnX/tmX9Cz0QuPT2dXr16AWBhYQFAeXm57ufRo0fzww8/GChEIYQxJWUUUK6uxNrSTPZtEaIeqguexKXk1rluXIi6xKVIxUohrubX1pFgHxcqNVp+/euCqcNp1PRK5JycnCguLgbA1tYWOzs7kpOTaxyTn59f/+iEEEYXk5QLQAdvJ9m/SIh68G5tj5lKSVFpBRnZxaYORzQBGo2WuNRc4O8LAUIIGHFlVG77wSS5MHYdeiVyISEhnDx5Uvdzz549+fTTTzl8+DCHDh3is88+IygoyGBBCiGM53zylfVx3k6mDUSIJs7cTImPR1WxiupRFiGuJz27iOLSCszNlFIgR4ir9OrcBmtLFZeyizl3IcfU4TRaeiVyEydOpLy8XDedcsGCBeTn5zN16lSmTp1KUVERzzzzjEEDFUIYx/nqEbl2sj5OiPrya+sEoBtlEeJ6qhN+Hw8HzFSy9YsQ1awszOjV2QOAXbKn3DXptf3A4MGDGTx4sO7ngIAAtm/fzv79+1GpVERERODk5GSoGIUQRlKmriQxvWoatIzICVF//l6OsF8qV4qbU12xUjYCF6K2ARFe7Dycwp7jF5k9pjMqudhRS702BL+avb09Q4YMMVRzQogGkJCah0ajxcneEncna1OHI0STV115sLrgiWxmK65HCp0IcW3hge442FqQW1jG8dgsIoNamTqkRqdeidzOnTvZtWsXqampALRt25aBAwcyaNAggwQnhDAu3f5x3k7ygVMIA/DxdESpVJBXWE52fimujnKBRNRNq72q0MmVKblCiL+ZqZT07eLJL/sS2XUkRRK5Oug1Rpmfn8+0adN4+OGH+fbbb4mNjSU2NpZvv/2Whx9+mGnTphm9auWmTZu4++67CQ0NpWfPnsyePZvS0r/3mvj9998ZPXo0oaGhDBs2jO+++65WG+Xl5bz55pv07duX8PBw/v3vfxMfH1/ruLi4OP79738THh5O3759+d///qdbHyhEU3Y+OReQ/eOEMBRLcxVeraq28ZCCJ+J6MnNKKChWY6ZS0N5DCp0IUZeBEVWbg0edTKNMXWniaBofvRK5119/ncOHD/PEE09w4MABdu7cyc6dOzlw4ACPP/44hw8f5vXXXzd0rDorVqzgtddeY8SIEaxdu5ZXX30VLy8vKiur/oMPHTrEo48+Snh4OGvWrGH48OH83//9H1u3bq3Rzn//+1+++eYbFixYwPvvv095eTkzZsygoKBAd0xeXh733XcfarWa999/nwULFrBhwwbeeOMNoz0/IRpKdcXKwHZOpg1EiGZEN71S1smJ64i9sj6uXRsHzM1Upg1GiEYq2McFNydrSsoqOHQmw9ThNDp6Ta3cvn0799xzD7Nmzapxu42NDbNnzyYtLY3vv//eEPHVEh8fz7Jly/jggw8YOHCg7vZhw4bpvl+xYgVhYWG8+uqrAPTq1Yvk5GSWLl3KnXfeCVRtav7tt9/y0ksvMX78eABCQ0MZNGgQX331FXPmzAHgq6++oqioiGXLlukKuFRWVvLKK6/wwAMP0Lp1a6M8TyGMrbBETWpmESAL7YUwJH8vJ3YeTtEVshCiLtWJfnXiL4SoTalUMDCiLd/tjGX30RT6hnmaOqRGRa8ROTMzM3x9fa95v5+fH2ZmBqujUsPGjRvx8vKqkcRdrby8nP379+sStmojRowgLi6OlJSqEqZ79uxBo9HUOM7JyYm+ffuye/du3W27d++md+/eNapwDh8+HI1Gw969ew34zIRoWLFXRuPauNrgaGdp4miEaD5kRE7cDF3FSqkYLMR1DYysml55MDqDohK1iaNpXPRK5IYNG8bWrVt1UxmvVlFRwS+//FIrkTKU48ePExgYyAcffEDv3r3p3LkzkydP5vjx4wAkJSWhVqvx8/Or8Th/f38A3Rq4+Ph4XF1dcXR0rHXc1evk4uPja7Xl4OCAu7t7nevphGgqYqr3j5P1cUIYlF9bRxQKyMotITu/9MYPEC2OVqv9u2KljMgJcV0+Hg54t7ZDXaEh6mSaqcNpVPQaNhs9ejSvvvoqkydPZuLEibRv3x6ACxcu8PXXX6NWqxk1ahSnT5+u8bhOnTrVO+DMzExOnTpFTEwML730EtbW1qxcuZKZM2eybds28vKq3hgdHBxqPK765+r78/PzsbevvbjYwcFBd0z1cf9sC8DR0bHGcYai1WopLi42eLu3oqSkpMZXYViNpX/PJmYB0L6Njclfc4bUWPq3OZM+vrF2re24kF7I0TMX6R3a5pYeK/1rXI2hf7PzS8ktLEOpVNDayVzeg8VNa6n927tza5IzCtl5OIk+nd2Mdh5D96+xt6HRK5GbOnWq7vuTJ0/qAtRqtbrbp02bpvu++kmcOXNG3zhrtFVcXMx7771Hx44dAejSpQu3334769ato1+/fvU+hymp1WqD9JMhJCYmmjqEZs3U/Xs2MRsA84rcRvOaMyRT929LIH18ba0dtFxIh33H4nEyy9GrDelf4zJl/55LqfqQ6OZgRlxsjMniMCZ5/RpXS+vf1jYVAJyMu8zBI6ewszZugSBD9q+FhYXB2vonvRK5hQsXmmzPKQcHB5ycnHRJHFStbQsJCSE2Npa77roLoEblSUC3HUL1VEoHBwcKCwtrtZ+fn19juqWDg0OttqBqZO+f0zINwdzcnICAAIO3eytKSkpITEzEx8cHa2vZA8nQGkP/ZueXUlCSgkIBt/UOxcqi+VRMawz929xJH99YbmUGB2JOkJGvIDg4+JYeK/1rXI2hf0+lxQGXCfZ1u+XXR2PXGPq3OWvJ/fvL0WJiU/K5XO5A98h2RjmHofs3NjbWAFFdm16J3NixYw0dx00LCAggKSmpzvvKyspo164d5ubmxMfH079/f9191evZqte7+fn5kZWVVSsh++eaOD8/v1pr4QoKCsjMzKy1ds4QFAoFNjY2Bm9XH9bW1o0mlubIlP17Ir5qWnD7Ng64ODXP/Yvk9Wt80sfXFtnRAzhBUkYhGoU5dtbmt9yG9K9xmbJ/kzKqplIGtndttv/H8vo1rpbYv7d1bUdsyimiTl1i7O0db/yAejBU/xp74EuvYifPPvusrrhIQxs0aBC5uTWnguXk5HD69Gk6deqEhYUFPXv25Ndff63xuC1btuDv74+XV1Xlm379+qFUKtm2bZvumLy8PPbs2cOAAQN0tw0YMIB9+/bV2OB869atKJVK+vbta6ynKYRRxSRVTfXqINXShDAKZwcrPNxs0WrhTMJlU4cjGpm41FxAtn4R4lb0D2+LQgFnL+SQfrnI1OE0Cnolcps2bbrmqJixDRkyhNDQUObNm8eWLVvYsWMHDz74IBYWFtxzzz0APPTQQxw7doyXX36Z/fv3s3TpUn7++Wfmzp2ra6dNmzaMHz+e//3vf3z33Xfs2bOHRx99FHt7eyZPnqw7bvLkydja2vLII4+wZ88evvvuO/73v/8xefJk2UNONFnnk3MBSeSEMKbOfq4AnI6XRE78LaeglMt5pSgU4OspFSuFuFkuDlaEBVQVOvnzWKqJo2kc9ErkTEmpVLJ69WrCw8N58cUXeeyxx7Czs+OLL77A3d0dgG7duvH+++9z+PBhZs2axc8//8x///tfhg8fXqOt559/nvHjx7N48WIeeeQRzMzM+Pjjj2tUs3R0dOTTTz9FpVLxyCOPsHjxYsaPH88zzzzToM9bCEPRarV/J3LtZOsBIYwlxFcSOVFb9bYDbd3tsLY0zp67QjRXAyKqZtbtOpJi4kgaB73fQUxV7ATAxcWFt95667rHDB48mMGDB1/3GAsLC55++mmefvrp6x7n7+/PJ598cqthCtEopWUVUVSixtxMiY9H7a01hBCG0enKiFxsSi5l6koszZtPUSGhP5lWKYT++oR6sOK7E1xILyAxLb/Ff47RO5F78sknefLJJ695v0KhIDo6Wt/mhRBGEnNlNM7P0xEzVZMblBeiyWjjaoOLgxXZ+aXEXMghNMB4ex+JpkO3EbiXTKsU4lbZ2VjQtWMr9p9OZ/fRFHw8QkwdkknpncgNGTKEoKAgQ8YihGgA56sLnbRzMm0gQjRzCoWCTn6u/HkslVPxlyWREwDEpeQC4N/WyaRxCNFUDYz0Yv/pdHYdTWXa8GCTzhI0Nb0TuaFDhzJq1ChDxiKEaAB/FzqR9XFCGFsnXxf+PJZKtKyTE0B+UTmXcqo2A/drKyNyQuije0hrrC1VXMou5tyFHDr6uJg6JJOReVVCtCAVlRriUqum9QTKiJwQRhdyZZ3c2QvZVFZqTByNMLXq0TgPN1ts9dhbUAgBVhZm9OzsAUjRE0nkhGhBktILKFdXYmNlhqebnanDEaLZa9/GAVtrc0rLK3UXUUTLVf0a8JfROCHqZeCV6pV7jl9s0RfJ9ErkduzYwZAhQwwdixDCyM4nV62PC/ByQqlsuXPKhWgoSqWCEN+qaT+yDYGoHpGTipVC1E94oDv2NhbkFpZxPDbL1OGYjF6JXNu2bbG2tjZ0LEIII6teHxco+8cJ0WA6yX5y4gqpWCmEYZiplPQL9wRa9vRKmVopRAsSU12x0tvJtIEI0YJ08q9K5KITstFotCaORphKYYmatMtFAPhJxUoh6q16emXUyTTK1JUmjsY0JJETooUoLa/gQnoBIBUrhWhI/m2dsDBXUVBcTvKlAlOHI0wk4cr6uFYuNjjYWpg4GiGavmAfF9ycrCkpq+DQmQxTh2MSksgJ0ULEp+ah0WhxtrfEzcnK1OEI0WKYmynp2L7q4olsQ9Byxer2j5NplUIYglKpYGBEW6DlTq+URE6IFuLq/eNa8uaZQphCJ7/qdXLZJo5EmIqsjxPC8AZcmV556EwGRSVqE0fT8OqdyBUVFREXF0dcXBxFRUWGiEkIYQTnk3IB2T9OCFP4u+BJFlqtrJNrieJScwGpWCmEIfl6OuDd2g51hYaok2mmDqfB6Z3InThxgmnTptGjRw9GjhzJyJEj6dGjB9OnT+fkyZOGjFEIYQAxydWFTmR9nBANLai9Myqlgqy8Ui7llJg6HNHAikvVpGYWAuAnUyuFMBiFQqEbldt9tOVNrzTT50HHjx9n2rRpmJubM378ePz9/QGIi4tj8+bNTJ06lc8//5ywsDCDBiuE0E9BcTlpWVUj5gFSsVKIBmdlaUaAlxPnknI4HX+Z1i42pg5JNKCEi/loteDqaIWzvaxRFsKQBkS05YutZzl+PpOcgtIW9TumVyK3ZMkSWrduzfr163F3d69x39y5c5kyZQpLlizh448/NkiQQoj6qd52wMPVVqqlCWEiIX6unEvKITrhMrd38zZ1OKIBybRKIYzH082ODt5OnE/OZc+xi4zq72fqkBqMXlMrjx8/zqRJk2olcQBubm5MnDiRY8eO1Tc2IYSBVJfl7XxlPyshRMPr5OsCwKk4qVzZ0ugKnci0SiGMYmBky5xeqVcip1Qqqay89sZ7Go0GpVIKYgrRGGi1WvafTgegV2cPE0cjRMsVfKXgSWpmIbkFZSaORjSk81fWKPvLiJwQRtE/vC0KBZy9kEP65ZZTfFGvbCsiIoIvvviC1NTUWvddvHiR9evXExkZWe/ghBD1F5+aR2ZOCZYWKroE1h5FF0I0DAdbC9q3sQcgOkFG5VqK6ITLJGcUYqZSEtReik0JYQwuDlaE+rsB8Oex2vlJc6XXGrnHHnuMe++9l+HDh3PHHXfg4+MDQEJCAjt27EClUvH4448bMk4hhJ7+OlU1GhcZ1ApLc5WJoxGiZQvxc+VCegGn4y/TJ8zT1OGIBrBxZywAg7t742hnaeJohGi+BkZ6cSI2i11HUpgwONDU4TQIvRK5kJAQvvnmG5YsWcLvv/9OSUlVKWVra2v69+/P/PnzCQgIMGigQgj97D9dta9Kz05tTByJEKKTryu/7EvktIzItQjJGQXsP52OQgF3D/Q3dThCNGt9Qj1Y8d1xLqQXkJiWj4+Hg6lDMjq9EjmAgIAAli9fjkajITs7GwAXFxdZGydEI5J+uYiEi/koFdA9RBI5IUytk1/VOrmE1DyKS9XYWJmbOCJhTJv+qBqN69XZA69W9iaORojmzc7Ggq4dW7P/dDq7j6bg4xFi6pCMrt5Zl1KpxM3NDTc3N5RKJRUVFYaISwhhAAeuFDkJ8XOVbQeEaATcnKxp7WKDRgtnErNNHY4wost5Jew8nAzA2EEyS0mIhjDwyubgu46motVqTRyN8emdyH333Xe89tprbN++HYDly5cTERFBREQE8+bNo7Cw0GBBCiH0U70+TqpVCtF4VI/KnY6X6ZXN2U9/xlNRqSXE14WO7V1MHY4QLUL3Tq2xslBxKbuYs4k5pg7H6PSaWrl69WreeecdlEol69ev56GHHmL16tWMHTuW0tJSfv75Zzw8PHj22WcNHa8Q4iblF5Xr1uHI+jghGo9Ofq78fiiZ6AQZkWuuikrU/BKVCMC4QR1MG4wQLYiVhRkDIrzYtv8C2QWlpg7H6PRK5L777jv69OnDypUrWbNmDR988AGPPPIIDz/8MAA2NjZs375dEjkhTOjQmXQ0Gi0+Hg60cbU1dThCiCuqR+RiknIoV1diIdVkm51f/0qkuLQC79Z2dAtubepwhGhR5ozpzG1dveh85b22OdNrauXFixcZPnw4FhYWjB07lsrKSkJDQ3X3h4WFkZGRYbAghRC3TqZVCtE4ebrZ4mRnibpCw/nkXFOHIwxMXVHJD7vjARh7WwBKpcLEEQnRslhZmhHq74ZC0fx/9/RK5NRqNVZWVgC6r2Zmfw/umZmZUVlZaYDwhBD6KFNXcuTcJQB6dpZplUI0JgqFQtbJNWO7jqSQnV+Ki4MVAyO9TB2OEKIZ03v7gfj4eA4ePEhBQQEA586d0yVzcXFxholOCKGX4zGZlJVX4uZkjX9bR1OHI4T4hxA/F/aeuCj7yTUzGo2WjVe2HBgzwA9zM5k2K4QwHr0TuRUrVrBy5Updac833nhDN4Sp1WpbxHCmEI3VX6eqNgHv1amN/C4K0Qh18q0akTuTkE2lRotKpt81C4fOZpCcUYiNlRnDevmYOhwhRDOnVyL32WefGToOIYSBVGq0HIiW9XFCNGY+no7YWJlRXFpBwsU8ArycTB2SMICNO6tG44b39sHWWjZ7F0IYl16JXI8ePQwdhxDCQM5dyCavsBxba3M6+Tf/ik1CNEUqpYJgHxcOn71EdPxlSeSagbOJ2ZyOv4yZSsGo/n6mDkcI0QLoVexk+vTpREVFGToWIYQBVFer7B7cGjOVXr/iQogGUF3w5JQUPGkWqtfGDerqjaujtYmjEUK0BHp9yjtw4ABZWVmGjkUIUU9arfbv9XEyrVKIRi3kyjq56ITLuvXmomlKuVSge+/9120BJo5GCNFSyOV6IZqR5IwC0rKKMFMpiQhyN3U4QojrCGznhLmZkrzCclIzC00djqiH73fFodVCj5A2eLe2N3U4QogWQu+qlbm5uVy8ePG6x3h6eurbvBBCD/tPV02rDA90x8ZKFtoL0ZiZm6kIbOfM6fjLnI6/jFcrSQCaopz8UnYcTAZg7CAZjRNCNBy9E7mFCxeycOHC6x5z5swZfZsXQuihempPz06yCbgQTUEnP1ddIifl6pumn/bEU1GpoWN7Z0J8XUwdjhCiBdE7kZs4cSLh4eEGDEUIUR+X80qIScpFoZBEToimorrgyemEbBNHIvRRXKpmy94EAMYO6iD7dgohGpTeiVy3bt0YNWqUIWMRQtTDgSvTKgPbOePsYGXiaIQQN6Nje2eUCriUXUxmTgnuzlLtsCnZtv8CRaUVtHW3lQtoQogGJ8VOhGgmqrcdkGqVQjQdNlbm+LV1BOB0gmxD0JRUVGr4YVccAP+6rQNKpYzGCSEaliRyQjQDxaVqTsRmAjKtUoimppOfGwDRsp9ck7L7aCpZeaU421syqKuXqcMRQrRAeiVyZ8+ebTTTKouKihgwYABBQUGcPHmyxn3ffPMNw4YNIzQ0lNGjR7Nz585ajy8oKOC5556jR48eREREMG/ePC5dulTruCNHjjBp0iTCwsIYNGgQq1evln1/RKNx+MwlKiq1tHW3k9LXQjQxnfyqCmTIiFzTodVq2bjzPACj+vthYa4ycURCiJZIr0Tu9OnTfPHFF9e8/4svvmiwipUffPABlZWVtW7fvHkzL7zwAsOHD2fNmjWEh4fz6KOPcuzYsRrHzZ8/n7179/Lyyy/z9ttvk5CQwJw5c6ioqNAdc+HCBWbNmoW7uzurVq3ivvvuY+nSpXz00UfGfnpC3JS/TldvAi6jcUI0NdUbgyelF5BfVG7iaMTNOHz2EhfSC7C2VDG8j6+pwxFCtFB6JXJLliwhKirqmvfv37+fd999V9+YblpcXBzr169n7ty5te5bunQpd911F/Pnz6dXr168+uqrhIaGsnz5ct0xR48eZc+ePbz++uuMGDGCwYMH895773Hu3Dm2bdumO27t2rU4Ozvzzjvv0Lt3b2bMmMHMmTNZuXIl5eXyR1eYlrpCw6EzGYCsjxOiKXK0s8SrlR0A0TIq1yRs3BkLwLBePthZy56dQgjT0HtErlu3bte8v2vXrpw6dUrvoG7Wf//7XyZPnoyvb82rYcnJySQmJjJ8+PAat48YMYKoqChd8rV7924cHBzo27ev7hg/Pz+Cg4PZvXu37rbdu3czePBgLCwsarSVn5/P0aNHjfHUhLhpp+KyKC6twMneksB2zqYORwihB902BLJOrtGLScrhZFwWKqWC0f39TR2OEKIF0yuRKyoqQqW69nxwpVJJQUGB3kHdjK1btxITE8MjjzxS6774+HiAWgmev78/arWa5ORk3XG+vr619n3x8/PTtVFcXExaWhp+fn61jlEoFLrjhDCVqzcBl6ppQjRNksg1HdWjcQMjvWS7CCGESem1j1z79u3Zu3cv06ZNq/P+P//8E29v73oFdj0lJSW88cYbLFiwADs7u1r35+XlAeDg4FDj9uqfq+/Pz8/H3r52YQhHR0fdiGJ1QvrPtiwsLLC2tta1ZSharZbi4mKDtnmrUtJzOJdago9PiUnjaK5KSkpqfK0PrVarS+QiOjib/LXTGBiyf0XdpI8Nz8/DBoC41Dxy8goB6V9jqc/rN/1yMftOXgRgeM+28p5bB3l/MC7pX+MydP9qtdpaA0aGpFciN378eBYtWsSiRYt45JFHdElOfn4+y5Yt488//+Spp54yaKBXW7FiBa6urowbN85o5zAVtVrdYIViruWLP7I4f7EUpeIsHTxlY2ljSUxMrHcbqZfLyc4vw9xMgao8kzNnsuofWDNhiP4V1yd9bFiONiryiivZe+Q8/m2spH+NTJ/+/flADlotdPC0oignhTM5ho+ruZDXr3FJ/xqXIfv36qVZhqZXIjd9+nTOnj3Lp59+yueff06rVq0AuHTpEhqNhjFjxjBjxgxDxqmTmprKRx99xPLly3WjZdVXxIqLiykqKsLRsWpz1YKCAtzd3XWPzc/PB9Dd7+DgQHp6eq1z5OXl6Y6pHrH751TR8vJySkpKdMcZirm5OQEBAQZt81b5nD/N+YsXSbysZPTgYJPG0hyVlJSQmJiIj48P1tb1m5ZzYnvVFJ/IIHfCOocYIrwmz5D9K+omfWwcoacq2HMinfxya0Ar/Wsk+r5+cwvLOL5hDwD33NmJYF8XY4XYpMn7g3FJ/xqXofs3NjbWAFFdm16JnEKhYNGiRYwZM4Zt27bp1pwNHjyYoUOH0rNnT4MGebWUlBTUajX3339/rfumT59Oly5dWLx4MVC1Bu7qtW3x8fGYm5vrpn36+fkRFRVVa9gzISGBwMBAAGxsbPDw8Ki1Fi4hIQGtVltr7Vx9KRQKbGxsDNrmreoT5slvBy9yLDYbC0srzFSyb7wxWFtb1/v/+vC5qhG4vl28TP66aWwM0b/i+qSPDSsssDV7TqRzPrWQiHa20r9Gdqv9+8OfSagrNAS2c6JrSFujTpdqDuT1a1zSv8ZlqP419vuEXolctV69etGrVy9DxXJTgoOD+eyzz2rcdubMGRYtWsQrr7xCaGgo3t7e+Pj4sHXrVoYMGaI7bsuWLfTu3Vs3xDlgwAA++OADoqKi6NOnD1CVoEVHRzN79mzd4wYMGMCOHTt48sknMTc317Xl4OBARESEsZ9yg+vYzglbKyVFJRWcjM0iIqiVqUMSdUjLKuJCegFKpYLuwa1NHY4Qop46Xyl4cj45j4oe8gGtMdFqtew8nALAqH5+ksQJIRqFeiVyGRkZHDx4kMuXLzNs2DDatGlDZWUlBQUF2NvbX7eypb4cHByuOeLXqVMnOnXqBMDcuXN54oknaNeuHT179mTLli2cOHGCdevW6Y6PiIigX79+PPfcczz99NNYWlqyZMkSgoKCGDp0qO64WbNm8dNPP/H4448zZcoUYmJiWLt2LQsWLDDqvFdTUSoVdPSy5nBsEftOpkki10jtv7IJeGc/V+xsmt/rUIiWxquVHQ62FuQXlZOWXU6oqQMSOueTc0m7XISlhUr26xRCNBp6JXJarZY33niDL774goqKChQKBYGBgbRp04bi4mJuv/125s2bZ7R1cjdj5MiRlJSUsGbNGlavXo2vry/Lli2rNYL27rvvsmjRIl588UUqKiro168fzz//PGZmf3dN+/btWbt2LW+88Qb3338/Li4uzJs3j5kzZzb002owwd5Vidxfp9J4cGwYKilr3+j8dapqfad8qBCieVAoFIT4uvDXqXQuZJaZOhxxlV1HqkbjenZqg5Vlva6BCyGEwej1bvThhx/y2WefMWfOHHr37s2///1v3X329vYMHTqUbdu2NVgi17NnT86dO1fr9gkTJjBhwoTrPtbe3p6FCxeycOHC6x4XGRnJhg0b6hVnU+LTyhJbKzNyC8o4m5it2+NINA55hWWcSajab6pn5zYmjkYIYSid/Nz461Q6CemSyDUWlRotfx5LBar2jhNCiMZCryoW33zzDXfffTePPfYYHTt2rHV/UFCQlEVt4sxUCrp2rKr4Wb1njmg8Dkano9GCX1tHWjnLWhohmotuwVVT2RMyyigsUZs4GgFwKjaLnIIy7G3MiQiUpQZCiMZDr0QuLS3tukU+rK2tKSws1Dso0Tj0CKn6gxV1Mg2tVmviaMTVZFqlEM2TVyt7vFrZotHC4bOZpg5HALuOVk2r7NulLeZmUsVZCNF46PWO5OrqSlpa2jXvP336NB4e8gGzqesS4IqVhYrMnBJiU3JNHY64orS8gqMxVR/wesm0SiGanZ4hVVVoD0RfMnEkolxdyb4TVbNSBka0NXE0QghRk16J3B133MFXX32l2z8O/t4nYc+ePWzatIk777zTMBEKk7EwV9H1Sln7fSeunbiLhnUsJpNydSWtXGzw8XAwdThCCAPr1alqNsTx2MsUl8r0SlM6fDaDotIK3BytCPGVteJCiMZFr0Ru3rx5uLu7M2bMGJ5++mkUCgVr1qxhypQpzJkzh8DAQB588EFDxypMoG+oJwD7TlyU6ZWNxF+nqpLqXp3ayF5GQjRD3q3tcLE3Q12h4dCZDFOH06LtOlpV5KR/hBdKqd4shGhk9Erk7O3t2bBhA7NnzyYjIwNLS0sOHjxIQUEBjzzyCOvXr8fa2trQsQoT6BrcCnMzJRezikhKLzB1OC1eZaWGA6erPtjJ+jghmieFQkGId9XfUJkNYTrFpWoOnq5ajyzTKoUQjZHem6FYWVnx8MMP8/DDDxsyHtHI2FhVVek6EJ3OvpNptJepfCZ1JjGbguJy7G3MCfF1MXU4QggjCWlnzZ7oAg6dzaC0vAIrC9m7rKH9dSqN8goNXq3s8GvraOpwhBCiFim/JG6od2jVyE/1gm9hOtXVKruHtEGlkl9fIZorD2dz3J2sKCuv5MhZKXpiCruOVE2rHBDhJdPYhRCNkl6X+J599tkbHqNQKG64ybZoGnp2boPyGwWJaflczCrE083O1CG1SFqtlv2nr6yPk2qVQjRrCoWCHiGt2LwviX0n0ugT5mnqkFqU3IIyjp2vqg4s0yqFEI2VXonc/v37a/ys1WpJT0/H1dUVCwsLALl61YzY21gQ5u/GsfOZRJ1IY9ztHUwdUosUk5RD+uViLC1UsimtEC1Ar06t2bwviQPR6agrKjE3U5k6pBZj7/FUNBotHbyd8HSXi5dCiMZJr0Tu999/r/FzdnY2ffr04a233qJ3794GCUw0Ln3CPKoSuZOSyJnKzsNVm9L27uyBlaWslxGiuQvwcsTFwYrs/FKOxmTSI0RG4htKdbXKgZFeJo5ECCGuzSCLbGT0rfnr1dkDhQLOJeWQlVti6nBaHHWFht1HqxK5Qd28TRyNEKIhKJUK+oTJGuWGln65iDOJ2SgU0K+LTGkVQjReBknkiouLAVCpZNpHc+XsYEWwT1WVxKiTUg67oR06k0FBsRoXB0u6dHA3dThCiAZSvTZu/6l0Kio1Jo6mZfjzWNVoXKi/G66OspWSEKLxqncil5GRwbvvvotSqcTPz88QMYlGqnf15uAn5cpwQ9t5OBmA2yK9UcmmtEK0GCG+rjjZWVJYouZEbJapw2kRdsu0SiFEE6HXQpuOHTvWmk756KOP4ubmZpCgROPUJ9SDtT+eIjr+MrkFZTjZW5o6pBahoLicg9FV2w7ItEohWhaVUkGvUA+2RiWy78RFIoOk0JExJablk5iWj5lKSZ8rW+8IIURjpVci98gjj6BQKFAoFLi6uhIeHk7Hjh0NHZtoZFq52BDg5UhsSh77T6cxrJePqUNqEf48lkpFpRY/T0d8ZEN2IVqcPlcSub9OpfHQuC4yKm9E1WuRu3ZshZ2NhYmjEUKI69MrkZs7d66h4xBNRJ8wT2JT8th3UhK5hvL7oapplTIaJ0TLFBrghp21OXmF5UTHXyY0QGa/GINWq5VqlUKIJsUgxU5Ey9H7ylSTE+czKSxRmzia5u9iZiHnLuSgVCpkU1ohWigzlZJenaV6pbGdu5DDpexirC1VdA9pbepwhBDihvQakZs+ffoNj1EoFHz66af6NC8aMa9W9rRrY09SegEHo9MZ1FVGiYzp9ytFTiIC3XF2sDJxNEIIU+kT5sH2g0nsO5nGnLtDUcr0SoPbdaRqWmWvzh5YWchenUKIxk+vEbkDBw5w8OBBiouL0Wq1df7TaKRMcnPVp7p6pVwZNiqNRqvbBPx2mVYpRIsWHuiOjZUZ2fmlnLuQY+pwmp3KSg1/HpdplUKIpkWvS05PPPEEa9asIT09nYceeojJkyfLHnItSJ8wD7767RxHzl6itKwCK0u5cmkM0QmXuZRdjI2VGT07S/U0IVoyczMVPULa8MeRFPadvEiwr4upQ2pWjp/PIq+wHAdbC9mrUwjRZOg1Ijd79my2b9/OmDFjeOuttxgxYgS//PKLoWMTjZSPhwMerraUV2g4fPaSqcNptqpH4/qGeWJpLhdKhGjp+oT9vU5Oq9WaOJrmZdeVapX9unhippLyAUKIpkHvdyt7e3uefPJJfv31V7p168YTTzzB+PHj+euvvwwZn2iEFAqFruiJbA5uHGXqSvZcmeYj1SqFEAARQa2wtFBxKaeE2JRcU4fTbJSpK4k6mQbItEohRNNS78tOrVu35vXXX+fHH3+kdevW/Pvf/2b27NmcPXvWEPGJRqr6yvDB6AzUFZUmjqb5OXAqneLSClo5W9PJ19XU4QghGgErCzO6BVdVU9x3Is3E0TQfh6IzKCmrer/t2F6mrAohmg69FjctW7asztuDg4MpLS1lz549REVFcfr06XoFJxqvDt7OuDpacTmvlGMxmXQPaWPqkJqV6mqVg7p6S3U6IYRO31BP9h6/yN4TF5k+IhiFQt4f6qt6WmX/8LbyfiuEaFIMmshdrbJSRmmaM6Wyanrlz3sS2HciTRI5A8opKOXIuaq1hzKtUghxta7BrTA3U5KWVURiWj6+no6mDqlJKyxRczA6A5BplUKIpkevRE6mTQqo2obg5z0J7D+dRmVlF1SyQNwgdh9NRaPREtTOmbbudqYORwjRiNhYmRMZ1Ir9p9PZdyJNErl6+uvkRSoqNbRrY4+Ph4OpwxFCiFsin7yF3kL8XHG0s6CgWM2puMumDqfZ+P3QlWmVMhonhKhDn7Are3lKsal623Xkyt5xEV4yTVUI0eToNSJ38eLN/fHw9PTUp3nRRKiUCnp28mDb/gvsO3mRLoGy9059XUjLJz41DzOVgv7hbU0djhCiEerRqQ1mKgVJ6QUkZxTg3dre1CE1STkFZZyIzQRgQIS83wohmh69Ernbb7/9pq5cnTlzRp/mRRPSJ6wqkfvrVBoP/CtMForX084rRU66BbfGwdbCxNEIIRojO2tzunRw5/DZS+w7eZFJrYNMHVKTFHUqA40Wgto708bV1tThCCHELdMrkQOYMGECERERhoxFNEFhAe7YWpmRnV/GuQs5BPtK6WZ9VWq0uk3Ab5dplUKI6+gT5lmVyJ1IY9IQSeT0sffKFg4DI6TIiRCiadI7kevevTujRo0yZCyiCTI3U9K9Uxv+OJzCvpMXJZGrhxPnM8nOL8Xexly3V5QQQtSlZ6c2LFcqiE/NI/1ykYwo3aLsggpiU/JRKqBfuCwDEUI0TVLsRNRbn9CqzcH3nUxDq9WaOJqmq3paZb/wtpibqUwcjRCiMXO0syTU3xWAfSek6MmtOnmhGICwDu4421uZOBohhNCP3iNyv/32G8nJyVhYWGBjY4O7uzt+fn74+/sbMj7RBEQEtcLSQsWl7GLiUvMI8HIydUhNTklZBftOVk3zkWmVQoib0SfMk+Pns9h3Io2xgzqYOpwmQ6vVcjKxKpGTaZVCiKZM70Ru27ZtbNu2rcZtCoUCd3d35s6dy4QJE+odnGgarCzM6NqxFftOpBF1Mk0SOT1EnbxIWXklnm62BLVzNnU4QogmoHdnD1ZuPMG5pBwyc0pwd7Y2dUhNwoX0QrLyKzA3U9L7yowSIYRoiuq1IXhlZSVqtZr8/HyysrKIjY1ly5YtvPjii9ja2jJixAiDBisarz6hnuw7kca+ExeZNjzY1OE0OdV7x93ezVv2MhJC3BRnBytCfF05HX+ZqJMXGT1AZsTcjL0n0gGIDHTD1trcxNEIIYT+6rVGTqVSYWVlRatWrQgJCWH06NGsXLmSvn378sknnxgoRNEUdA9pjZlKScqlQpIzCkwdTpOSlVvCidgsAG7rKtMqhRA37+o1yuLGNBote09WJXJ9w9qYOBohhKgfoxQ7mT9/PkOHDjVG06KRsrEyJ/zKhuCy8P7W/HEkBa0WOvm50trFxtThCCGakN6hVRUXoxMuk5NfauJoGr8j5y5xOa8US3MFEYFupg5HCCHqxSiJXOfOnZk9e7YxmhaNWPWV4d3HUqmo1Jg4mqZBq9XWmFYphBC3wt3ZmqB2zmi1EHVKRuWuR12h4cMfTgEQ6W+LhblUBxZCNG16J3KFhYUsW7aM8ePH06dPH/r06cP48eNZtmwZhYWFhoyxhl9++YWHHnqIAQMGEB4ezpgxY/j2229rlb3/5ptvGDZsGKGhoYwePZqdO3fWaqugoIDnnnuOHj16EBERwbx587h06VKt444cOcKkSZMICwtj0KBBrF69Wsrs16FnZw+sLFQkpRfwwbfHpY9uQlxqHskZBViYKekbJnsZCSFuXZ+wK9MrZTbEdW3eG09qZiGOthYM7Oxg6nCEEKLe9ErkMjIyuPvuu1m2bBnFxcVERkYSGRlJSUkJy5Yt41//+ledCZEhfPLJJ1hbW/PMM8+wYsUKBgwYwAsvvMDy5ct1x2zevJkXXniB4cOHs2bNGsLDw3n00Uc5duxYjbbmz5/P3r17efnll3n77bdJSEhgzpw5VFRU6I65cOECs2bNwt3dnVWrVnHfffexdOlSPvroI6M8v6bMwdaCJ6d2Q6mA3w4k8fX2GFOH1OjtvDIa17Ozhyy6F0Lopc+Vi0An4y6TV1hm4mgap5z8Utb/eg6AKUMDsLKQbXSFEE2fXlUr3377bbKysli1ahUDBw6scd+uXbuYP38+ixcv5s033zRIkFdbsWIFLi4uup979+5Nbm4uH3/8MQ8//DBKpZKlS5dy1113MX/+fAB69epFTEwMy5cvZ82aNQAcPXqUPXv2sHbtWvr16weAr68vI0aMYNu2bbqKm2vXrsXZ2Zl33nkHCwsLevfuTXZ2NitXrmTatGlYWFgY/Dk2ZT06teGBsWGs+O4EX2w9i7uTNYO7tzN1WI1SRaWGXUdTAJlWKYTQXxtXW/zaOhKfmsf+0+kM7dne1CE1Op9tOUNJWQUdvJ0YGO7JuXP5pg5JCCHqTa9LUn/++Sf33XdfrSQOYODAgUybNo1du3bVO7i6XJ3EVQsODqawsJDi4mKSk5NJTExk+PDhNY4ZMWIEUVFRlJeXA7B7924cHBzo27ev7hg/Pz+Cg4PZvXu37rbdu3czePDgGgnbiBEjyM/P5+jRo4Z+es3CiD6+jBsUAMD7G45xLMY4o7NN3fHYy+QVluNkZ0nElUIxQgihD5leeW0xSTlsP5gEwP3/CkWplC1ehBDNg16JXElJCa6urte8383NjZKSEr2DulWHDx+mdevW2NnZER8fD1SNrl3N398ftVpNcnLVVLb4+Hh8fX1r7dnl5+ena6O4uJi0tDT8/PxqHaNQKHTHidqmjwhhQERbKjVaFn5ykISLeaYOqdH581hVYYKBkV6oVDLNRwihv+o1tsfPZ1JYojZxNI2HRqNl1aYTQNXMh47ta18MFkKIpkqvqZX+/v5s3ryZyZMn15paqFar2bx5M/7+DbMx6aFDh9iyZQtPP/00AHl5VQmDg0PNhczVP1ffn5+fj729fa32HB0dOXWqqqpVQUFBnW1ZWFhgbW2ta8uQtFotxcXFBm/3VlQn4fVNxu8f3ZGsnGKiE3N4eU0U/72/B66OVoYIsUkrKSmhpFzDwTNVI5W9O7mZ/P+8OTHU61dcm/SxcenTvy52Krxa2ZJyqYj/LN7J8N7tGBTpibWlXn/mm40/jlwkJikXa0sVE2/3pbi4WF6/Rib9a1zSv8Zl6P7VarW1Bo0MSa93+Dlz5rBgwQImTJjAPffcg4+PDwAJCQl89dVXnDt3jiVLlhgyzjqlp6ezYMECevbsyfTp041+voagVqs5c+aMqcMAIDExsd5tjOpmTWZOAZl5Zby8JoqZd7SSReZAdFIxFZVaWjmaUZKbwpk8mepjaIZ4/Yrrkz42rlvt30GdrPkur4RLOSV8uuUcX/0WQ9cAW3oE2uFk2/ISutJyDZ/9UrX5d78QO9JT4km/6n55/RqX9K9xSf8alyH715j1NPR6Zx8+fDglJSUsXryYl156SZdparVaXF1dWbhwIXfeeadBA/2n/Px85syZg5OTE++//z5KZVVy4OjoCFSNprm7u9c4/ur7HRwcSE9P55/y8vJ0x1SP2FWPzFUrLy+npKREd5whmZubExAQYPB2b0VJSQmJiYn4+PhgbW1d7/a82/vx/KoDXMor5+cjpTw7LQIzs5abzJWUlPDRbwcAuKOXLyEhPqYNqJkx9OtX1CZ9bFz69m9wMAztX8nuY2ls3pfExawi9p0p5K9zRfTq1Iq7+rQnwMvwf7caq8+3xlBUqsHD1YYZo7vp/u7I69e4pH+NS/rXuAzdv7GxsQaI6tr0vkQ3duxYRo8ezalTp7h4sWpxtaenJ507d8bMzLhX/kpLS3nggQcoKCjg66+/rjFFsno9W3x8fI21bfHx8Zibm+Pt7a07LioqqtaQZ0JCAoGBgQDY2Njg4eFRay1cQkICWq221to5Q1AoFNjY2Bi8XX1YW1sbJJb2Nja8PKc3z36wh1Px2Xz48zkWTIk06lBzY5aRXUxSZjkKBdzR0xcbG3kjNgZDvX7FtUkfG5c+/WsDjB5oz8j+HThy7hLf74rl+Pks9p3MYN/JDEJ8Xbh7YAA9OrVB1YyLfiRnFPBLVFWBkwfGhuHgYFfrGHn9Gpf0r3FJ/xqXofrX2J91b3pYpK7Nnc3MzAgPD2fEiBGMGDGC8PBwXRKXmppquCivUlFRwfz584mPj+fDDz+kdevWNe739vbGx8eHrVu31rh9y5Yt9O7dWze8OWDAAPLy8oiKitIdk5CQQHR0NAMGDNDdNmDAAHbs2IFara7RloODAxEREcZ4is2Sv5cTT0/vjlKpYOfhFL7YetYg7Wo0Wg5Gp/PD7jjK1ZUGadNYcgpK+eNICmt+rJo6G+rngqujJHFCCMNTKhV0C27Nfx/sy9LHb+P2bt6YqRREJ2Sz8JMDPPTGDn7eE09JWcWNG2titFota74/SaVGS4+QNnTt2PrGDxJCiCbopofO5s6dq9tL7Xo0Gg1r167lgw8+MEp5/ldeeYWdO3fyzDPPUFhYWGOT75CQECwsLJg7dy5PPPEE7dq1o2fPnmzZsoUTJ06wbt063bERERH069eP5557jqeffhpLS0uWLFlCUFAQQ4cO1R03a9YsfvrpJx5//HGmTJlCTEwMa9euZcGCBbKH3C3q2rE1j4zvwvsbjvH19hjcna0Z1stHr7aKS9VsP5jEz3sSSMsqAuBCWj7zJjWe5LqkrILT8Zc5FpPJ8fOZJKbV3Lfo9q5tTRSZEKIl8fV0ZMGUSKaPCGbz3gR+2ZdI2uUiVm06ybqtZ7mzV3tG9vPDzal5XFg6cDqdozGZmKmUzBrTydThCCGE0dx0Ird9+3ZmzZrFihUrsLOrPUUB4MSJE7zwwgucO3eOwYMHGyzIq+3duxeAN954o9Z9O3bswMvLi5EjR1JSUsKaNWtYvXo1vr6+LFu2rNYI2rvvvsuiRYt48cUXqaiooF+/fjz//PM1poa2b9+etWvX8sYbb3D//ffj4uLCvHnzmDlzplGeX3M3tGd7LuUU8/VvMXzw3QlcHa3pFnzzV0vTLxfx0554th9Iori06kqyrZUZJWUV/HYgiU5+ribbgLyyUsP55FyOnc/kWEwm5y5kU1H590i2QgF+bR3p5OOMs2UhvTrLVWIhRMNxdbRm+ogQJg4OZMehZH7YHUdaVhHf7Yzl+11xRAS1wquVHZ5utni62eHhboubo3WT2netXF3Jhz9WVZ7+123+eLrV/XlFCCGag5tO5F599VVeeeUVpk6dytq1a2vsI1dYWMg777zD119/jZubG8uWLWPIkCFGCfj333+/qeMmTJjAhAkTrnuMvb09CxcuZOHChdc9LjIykg0bNtx0jOL67h3WkcycEn4/lMybnx1k0cP9CPB2uubxWq2WU3GX+WF3HAei06me5dvW3Y5R/f24vZs3P+yO44utZ/nguxP4eznh4+FwzfYMRavVknKpkONXEreTcVm65LJaKxcbIgLd6dLBnbAANxztLCkuLubMmTMtdo2gEMK0rCzNuKuvL8N7+3AwOp3vd8dxKu4yh85kcOhMRo1jLcyUtHGzxdPNFg+3K0mee1Wi5+Jg1eiSvO93xZF+uRgXBysmDA40dThCCGFUN53ITZw4EWdnZx5//HEmT57M2rVradeuHb/++iuvv/46WVlZ3HPPPSxYsABbW1tjxiyaOIVCwaMTwsnOK+XY+UxeXfsXb80bQGuXmotKy9WV7D6awg+742tMS4wMasXoAX5EBLbSfYiYODiQMwnZHDl3iTc+Pcg78wdgY2VutOcQk5TDW+sOkX655v5vdtbmdOngTpdAdyIC3WnjKr8LQojGSalU0LOzBz07exCfmseZxGzSsoq4mFXIxcwiMrKLKK/QkJReQFJ6Qa3HW5irdIndiN6+dAl0r+MsDScrt4QNO2IA+PeoTi1+Dz0hRPN3S+9yd9xxB2vWrOGRRx5hypQpBAcHs2fPHoKDg1m+fDmhoaHGilM0M+ZmSp65rzvPLN9DYlo+r3wYxf8e7Y+djQXZ+aVs2ZvA1r8SySssB8DSQsXtXb0Z1d8P79a1N3JXKhU8dk8k89/5g9TMQpZ9c5wnp3Y1yqjXhbR8XlodRWGJGnMzJSG+LnTp4E5EYCt82zo260pwQojmya+tI35ta25NUFmpITO3hIuZV5K7rKKqRC+zkIzsYsrVlSSm5ZOYls/+U+k8MbUr/bqYbu3vJz9HU1ZeSbCPCwMjZA2yEKL5u+XLVT179uTzzz9n9uzZ7N27l1GjRvHGG2+gUqmMEZ9oxmytzXlpdi+eWLqb5IxCXvtoP61cbNhzLFW3tszNyZqRfX0Z2qs99jbXLy7jaGfJ09OrksM/j6XSydeFu/oZdouIi1mFvLBqH4UlaoLaO/Pq/b2NOvInhBCmolIpaeNqSxtXWyJpVeO+ikoNl3KKuZhZxPaDSew9fpG3Pj+EukLDoK7eDR7r6fjL7DqagkIB9/8rVKauCyFaBL12ZQ4ODubLL7/Ey8uLX3/9lR07dhg6LtFCuDlZ8/Kc3thYmRGdkM0fh1OoqNQS7OPC09O78eFzQxh3e4cbJnHVOvq4MGNkVZWyD388RUxSjsFizcot4YWV+8gpKMPHw+H/27vzuKiq/g/gnxlgAAERRAFFUsPGRAGNXCBxIa0UcntMcalc6ck07aVE5pam5Po87tpipqnhvoU9mlqau+KCoqkoKCKQIIois8D5/cGPEQISlcMw8Hn/lTP3zpz7afjC984952LK0NZs4oioSjI3U6KOky18X3bGuAG+6NTSHbkC+M+6aPzvaEK5jiUnV+DrLTEA8hbU8nCrUa7vT0RkLKX+Ru7ChQtFHpswYQLCw8MxZswYhIWFwdfXt9Dznp5c9peerL5rdXw+qCWWbjoHj3o18HbbhmhUz+GZX69bQEPEXk/DkZjbmLnqBP77SftSN4IlufdAg4nLDyP17iO4Otlgamgb2D7naxIRVQZmyrx5zxbmSkQdjseiDWeg1+eU+RURJdl9LAHXku7BxtoCA996uVzek4ioIih1I9erV69iL1XIv1F4RESE4XkhBBQKBS5evFhGw6TKzsujFpZ+Wja3rFAoFPi4T3PEJ93H7bSH+M+6aEwY1OqZV1d7+EiHyd8cQWLqAzjVsMaXoX5wsLMqk7ESEVUGSqUCH/T0gsrCDFt/j8OyLTHQ6HLRs4OH1PfNzNJidVTe3xr932gMe1tLqe9HRFSRlLqRi4iIkDkOojJlY22B8PdexdgFB3AiNgVbfruKXh0bPfXrZGv1mPrdUcQl3oO9rQrTQtug9t9W1yQioryTaIODPaGyMMP6Xy/j+50XoNPnoE8ntbT3XPvLJWRmaeHuYocufvWlvQ8RUUVU6kauR48eMsdBVOYa1rVHaI9mWLThLFbtugj1Cw5o+qJTqffX6XMR8cMJxF5Ph42VOaYO94Nb7aIrZhIRUR6FQoGBb70MlbkSP/5yCT/+cgkaXQ4GvvVymS9AEn/7PqIOXwcADO/eDGZmzzTtn4jIZLHqUaXWudUL6PCKG3JzBWb/eBJ3M7NLtV9OrsDctacQfSkVliozTB7apsjS3EREVLw+ndQYHJw3T37D3itYseOCYSpGWRAib4GTXAH4e9WBdyPj3sOOiMgY2MhRpaZQKPBhL2+4u9gh/b4Gc348hZzcf/5jQgiBxRvO4NDZJJibKfH5+y3xcgPHchoxEVHl0KO9Bz7okXd/2a2/x2HZ5nPIfUL9La1D55IQE3cHKnOloWEkIqpq2MhRpWdlaY7wd1+FlcoM567ewbrdl0rcVgiB77ZfwJ7jN6BUAOMGvILm6tolbk9ERCXr+lpDjHzHBwoFDCtaPulkWknu3s9G1OHrmLDsEGb/eAoA8K+OjThvmYiqrKe+ITiRKarnbIcRvX0wd80prP/1MprUr4kWjYs2aD/t/hPbDsQBAEb1aQ4/rzrlPVQiokqlc6sXYGGuxH/XRWPP8RvQ6nIxJqR5qea0paZn4XDMbRyJScLF+HQUvDrTp1Et9JC8KiYRUUXGRo6qjPYt3BB7LQ27jsRjzppTmP9Je9RysDY8v+1AHNbu/hNA3sT5wFfdjTVUIqJKpcMr9aAyN8PsH0/i99OJ0OXkYGx/X1iYF23mkv56gEPnknA45jau3swo9Jza3QFtmrmijZcr6jjZltPoiYgqJjZyVKUM7dYUl2/eRVziPcxafQIRI16DuZkSe44l4Ntt5wEAA95sjOC25XMjWyKiqsLfuw4szFsi4ocTOHzuNiL0xxH+7quwMFciITkTh88l4fC5JCQkZxr2USiAJg1qws/LFW2a1il08o2IqKpjI0dVisrCDOHvvorR837DpYS7WLkzFi/Xd8SiDWcAAN3bvYh3Xn/JuIMkIqqkWnq6YOLgVpj+/TGciE3Bp4v/QNYjHZLuPDRsY6ZUwMvDCW286qB1Uxc42FkZccRERBUXGzmqclxq2mB0SAtM//44th2Iw84/riFX5M3jGBzsWeb3OiIiosdaNK6NycNaY9p3xwyXTlqYK9H8pdrw83JFS08X2FVTGXeQREQmgI0cVUmtm7qiR3sPbPntKnJyBdr61MWH//JmE0dEVA68PGph+r/98euJG2jW0AmvvFwb1awsjD0sIiKTwkaOqqx3u7wMjVYPczMl3g/yhJmSTRwRUXl5yd0BL7k7GHsYREQmi40cVVnmZkr8u5e3sYdBRERERPTUeENwIiIiIiIiE8NGjoiIiIiIyMSwkSMiIiIiIjIxbOSIiIiIiIhMDBs5IiIiIiIiE8NGjoiIiIiIyMSwkSMiIiIiIjIxbOSIiIiIiIhMjEIIIYw9CMoTHR0NIQRUKpVRxyGEgE6ng4WFBRQKhVHHUhkxX7mYr3zMWC7mKxfzlYv5ysV85SrrfLVaLRQKBVq0aFEGoyvKXMqr0jOpKD+QCoXC6M1kZcZ85WK+8jFjuZivXMxXLuYrF/OVq6zzVSgUUv++5zdyREREREREJoZz5IiIiIiIiEwMGzkiIiIiIiITw0aOiIiIiIjIxLCRIyIiIiIiMjFs5IiIiIiIiEwMGzkiIiIiIiITw0aOiIiIiIjIxLCRIyIiIiIiMjFs5IiIiIiIiEwMGzkiIiIiIiITw0aOiIiIiIjIxLCRIyIiIiIiMjFs5IiIiIiIiEwMGzkiIiIiIiITw0aOiIiIiIjIxLCRIyIiIiIiMjFs5IiIiIiIiEwMGzmiSiY5ORmJiYnGHgYRUZXD+ktE5cnc2AOgqiMzMxM7d+6Eu7s7GjVqhNq1awMAhBBQKBRGHp3py8zMxLRp03DmzBkEBwejf//+cHR0NPawKo0HDx7g+PHjcHNzg4uLC6pXr27sIVUqmZmZWLt2LZRKJRo3bgwfHx/Y2dmxPpQR1l+5WH/lYw2WizVYrszMTGzYsAG1atVCkyZN0KBBAyiVyufOl40clYsNGzZgxowZqF27NjIyMmBnZ4chQ4YgJCSEBaIMnD17FmFhYXBycsIHH3yAhg0bwsHBwdjDqjS+/vprrFq1CjY2NkhMTESDBg0QFhaGgIAAYw+tUli3bh3mzZuHunXrIisrC3fv3kW3bt0wYcIE1ocywPorF+uvfKzBcrEGy7V161Z88cUXqFu3Lu7duwcA6NatG8aOHfvc+bKRI+lu3bqFNWvWIDQ0FD169AAAzJgxA0uWLIFSqUSfPn14xuc57d27F+7u7pg0aRJcXV1hbv74R5vZPruMjAzMnz8fR48exahRo+Dp6QmdToexY8fim2++Qd26dfHiiy8ae5gm7cyZM1i5ciVGjBiBrl27wsrKCgsWLMD+/fvRtWtXNG/e3NhDNGmsv/Kx/srDGiwfa7Bc6enpiIyMRP/+/TFo0CBYWFhg+fLlWLNmDapVq4YPP/zwuV6fc+RIuitXruD69evw8/ODs7MznJ2dMW7cOLRv3x4RERG4ffs2f9E9B61Wi61btyIwMBD16tWDubk5kpKSEB0djaysLGb7HG7cuIG9e/diwIAB6NGjBzw9PeHj44OwsDCcOXMGqampxh6iyduzZw80Gg06dOiAWrVqwc7ODh06dEBaWhqsra2NPTyTx/orF+uvXKzB8rEGly0hRKF/37p1C2fPnoWfnx9q1qyJ6tWrY9iwYRgyZAiWLFmC48ePP9f7sZEj6e7cuQNra2vUqFHD8JibmxsGDhwIFxcXREREACj64acnE0Lgr7/+gr29PRwcHJCTk4Px48cjODgYI0eORN++fbFy5UpjD9NkOTg4IDw8HP3794eFhQUAICcnB6+++ioAICUlxZjDM2kFf94VCgXs7OwM/9br9Xj11VcL1QzWh2fD+isP6698rMHysAaXveK+gU9PT4e9vT2UysctV40aNTBgwAA0a9YMCxcuRGZm5jO/Jxs5KjORkZGIiIhAZGQk4uLiDI+3bt0aDx48wKVLlwAAOp0OANCwYUMMGTIEu3fvxoULF6BQKFgo/kFx+SoUCjg7OyM9PR23b9/Gd999h5iYGEyfPh3jx4+Hp6cnvvrqK+zZs8fIo6/4fv31V0Ouer0eQN4fvF26dAEA5ObmAgDMzMxw584dKBQKuLq6GmewJqhgvvlZAkDfvn2RlpaG8ePHIyoqCsuXL0doaCiuXr2KHj164LPPPsOtW7dYH56A9Vcu1l/5WIPlYg2Wa82aNRg/fjyWL19e6Fu2V155BdnZ2YYanJ9hjRo1MHLkSJw6dQpHjhwp9NzTYCNHzy0lJQV9+/bFokWLcOPGDcydOxdDhgwxfDDt7e3h6+uLJUuWAAAsLCwghIC5uTlat24NT09PLFu2DAB4GUoxSsr36NGjhhwDAwOxdOlS7NixA++99x7efPNNdO3aFZ999hm6du2KOXPmPNcZn8rszz//RN++ffHRRx9h1apVAGCY41Lw81jwbFpaWhqsrKy4oEEpFJdvwSzr1auH2bNnw97eHqtXr8Z3332H8PBwLFiwAKGhoYiOjsbYsWMBsD4Uh/VXLtZf+ViD5WINlistLQ3vvfceli9fDp1Oh8jISHzwwQfYvn07Hj16BFtbW3Tq1Alr1qyBVqstlKGXlxf8/f2xYsUKAM+WLxs5em5HjhzBvXv3sHTpUixZsgRr1qyBl5cXxo4dixMnTsDOzg5vv/02rly5gq1btwJ4fLbN2dkZvr6+SExM5CUSJfinfPPP+gQFBcHGxgZXrlyBu7s7gLwzO7a2tggJCUFCQgKio6MNj1Oe69evY8aMGbh//z6aNWuG06dP4+DBgwAKn7HMl/9YTEwMLC0t4ebmVq7jNTX/lG/Bz+Ebb7yBmTNnwsrKCn369MHAgQPRtGlTvP/++wgNDcXp06dx4sSJIvsR669srL9ysQbLxRosX0xMDG7evIl58+Zhzpw52LhxI3r27IkpU6Zg165dAIBevXohJSXF0EjnZ2hlZYWAgAAkJiYWupLiabCRo+e2f/9+2Nvbo2nTplAoFGjUqBHmzJkDa2trLF68GElJSWjfvj0CAgIwa9YsZGdnG84Kq1QquLu7Iy0trdC12PRYSflaWVlh6dKluHnzJry9vfHGG28AAC5fvozs7GwoFAoolUrY2dnB3t4ed+7cAcAzagWlpaUhNzcXo0ePxsSJEyGEwKZNm6DVag33dyko/yzmuXPn4O3tjWrVqiE3Nxe5ublITk42xiFUaE+T740bNxAbG4vg4GAolUpDs1G/fn3Y2NgY8uXntzDWX7lYf+ViDZaLNVi+3377DZaWlvD19QUAODo6YsKECWjSpAnWrVuHM2fOoFWrVujZsyeWLl2KuLg4Q4bm5uZwcnJCTk4ObGxsnun92cjRc8nJyTFMkH348CGAvDkYKpUKX3zxBU6dOoVdu3bB0dERgwYNglKpRHh4ODIyMqBQKKDX65GQkAAXFxfD3A16rDT57t69GyqVCn379sXLL7+MyMhInD9/HkDemfeLFy/CwsIC3t7eRjuOisrT0xNLly5F586d4eXlhYCAAFy4cAHbtm0rcR+NRoObN2/Cw8MDQN6KVJMnT8aoUaNw5cqV8hq6SXiafM3NzaFQKLBlyxbDv/V6PS5cuAAbGxs0adKkvIdf4bH+ysX6Kx9rsFyswfLkN8FOTk7QaDRIT08HkLeSLQCMHTsWaWlp2LZtG3Q6HYYMGQIXFxdMmTIFly9fBpD3DfONGzfg4OAAlUr1TOPgfeTouZiZmcHJyQlHjhzBlStX4OPjYzjb6+/vD39/f2zZsgVvvPEGWrZsialTp2LkyJFIT09H27ZtoVAosG3bNnzwwQewtbU19uFUOKXJd+vWrejUqRNeeOEFREREYNiwYfjss8/Qpk0b2NnZYfPmzejYsSPq1KnDexr9Tf7SyjqdDhYWFhg4cCBOnjyJnTt3IiAgAM7OzsjNzS0yNyMhIQENGzZEZGQk5s2bB1tbW8yYMQONGjUy1qFUSKXJNycnB2ZmZqhevTq6deuGH374ATVr1oS7uzsSExOxYsUKdOnSBXXr1uXn929Yf+Vi/ZWPNVgu1mB58nNwcnKCUqnEsWPH8NZbbxkaMh8fH7Rr1w5HjhzB2bNn4evri1mzZmHYsGH45JNP0LZtW9ja2mLVqlXo37//s8/3FETPKCcnRwghRGpqqmjSpImYP3++ePTokRBCCK1WK4QQ4sqVK0KtVos9e/YY9tu3b58YM2aM6N69u+jcubNYs2ZN+Q/eBDxrvhcvXhRz584VgwYNEj179mS+pZSbmyuEEGLNmjWiY8eOYuHChYUezxcVFSXUarVo0aKF8Pb2FqtWrSr3sZqi0uSbnJwsJk6cKJo3by46dOggOnXqJNatW2eU8VYUf//85WP9LRtlnS/rb1ElZVzSdqzBT6cs82UNLr383O7fvy/8/f1FeHi4SE9PF0I8rhFJSUnC29tbrFy50rDf2bNnxZdffin69esngoKCnrtGsJGjEt2+ffuJ2+T/sps6darw9/cXZ8+eNTyn0+lETk6O6N27txg3blyRfVNSUgz7V0Wy883Kyip1ga+MSpNvQflZaTQaERoaKnr06CHOnTsnhBCFPqf79u0TPj4+4quvvhI6na7sBmxiyjJfvV5faNvk5GRx5syZIo9XJceOHRMJCQkiLS2txG1Yf5+d7Hyrev0VonQZF8Qa/HTKMl/W4KJ27dolDh48KC5dumR47O8/0/n5LFmyRHh5eYldu3YZntNoNEIIIYYPHy4GDx5c5PXv379fJjWCc+SoiIMHD6Jly5YYN27cE5dMzr/cYcSIEcjJycHKlStx69YtAI+vt7axsYGZmZlh4qz4/+uKa9euXehyiapCdr75rK2tq+QlEE+Tb0EKhQK5ublQqVTo06cPHj58iI0bN0Kr1SImJgbnzp0DADRt2hR79+7Fp59+algiuyqRke/58+cRExMDIK8+ODs7w9vbG2ZmZrIOo8KKiopC586dMXnyZPTo0QPvvPMOjh8/XuwKfqy/T092vvmqav0Fni7jgliDS0dGvqzBj0VFRaFjx46YNWsWwsLC0Lt3b/z0009Fbh0APK4R//73v+Hs7IyffvoJFy5cAADDDewdHByQm5uL7OzsQvva2dmVSY2oelWcSqTX67Fx40Z8+eWXqFGjBqKjo7F3794n7ieEgKOjIz7//HPs378f33//veG51NRU3L59G2q1utj7wlQl5ZVvVfWs+RaU/9ns0KEDfH19cezYMYwbNw59+vTBokWLkJOTg1q1asHR0VHGIVRo5ZVvVa0P2dnZWLJkCebMmYMuXbogIiICM2fOhL29Pb788ssSl6Zm/S2d8sq3KnvWjAtiDS5ZeeVbVWvEw4cPMWXKFMycORPBwcFYtmwZIiMj0a5dO3zzzTe4evVqkX3yF40CgIkTJ+LGjRtYuHAhdDodFAoF0tPTcfnyZTRv3hxWVlZSxs3KQwbm5ubYvn07rKysMH78eKxfvx6LFy+Gn58fateuXeJ++T/0QUFBuHz5MrZv347Dhw/D398fZ8+eBQD4+/uXyzFUZMxXrmfNtyCFQoGcnBxoNBq4uroiPj4eqampGDt2LIYOHSr5CCo25ivXrVu3sGfPHnTt2hXDhw9HtWrVAABubm7o3r074uPj0ahRoyILP7A+lA7zle9ZMy6INaJkzFe+5ORkvPvuu+jXrx8sLS2hVCrx8ccfIygoqMSTNfmPt23bFsOHD8e3336LwMBAtGrVCgkJCcjIyED79u3lDfq5L86kSiH/OvNLly6Jhw8fCiGEOH/+vGjevLn473//+8T9869f12g0IiYmRoSHh4thw4aJSZMmGV6vKmO+cj1vvgWlpaWJYcOGCbVaLSZNmiSysrLKfLymhvnKFxcXJ9auXWuYVyFE3oT5u3fvioCAALFgwYIS92V9eDLmK9/zZFwQa0TxmK88+XPVrl69alioJN+ePXvEoEGDxL1790rcP79G5Obmilu3bolZs2aJ0aNHi2nTpkmvEQoheIv2quj333/HuXPn4OrqCn9/f7i6ugJAoTM5Wq0WixcvxurVq7Fu3Tqo1eonvq4osDStVqt95vtimDrmK5esfAEgMzMT69evR5s2barsfXOYr1wF8/Xz80OdOnUAPF4ivGDO9+/fR7t27TB16lQEBwf/4+uyPuRhvvLJyhhgjQCYr2wl/Y77u6ioKEybNg1mZmawt7dHx44dERQUBLVabbhtQ0EF/7/o9fryueRaaptIFc6DBw/Exx9/LHx8fMTgwYOFp6enCAoKEtu2bTNsU3AVnZs3b4rXX39dfPLJJ0XOUlBRzFcu5isX85WrNPn+3aVLl0SLFi3E0aNHy3Gkpon5yseM5WK+cj3N77gtW7YIPz8/MX36dLFz504xf/58ERgYKAYMGGCs4ReLjVwVc/DgQdG5c2dx4MABodFoxMWLF0VYWJjw8vISJ0+eNGyX/0HOzc0V69evF40bNxa///67sYZtMpivXMxXLuYrV2nzFeLxpTo///yz8Pb2FsnJycYYsklhvvIxY7mYr1xPk29SUpJISkoq9NiKFStEmzZtCt070ti4amUVc+zYMTx69Aht27aFSqVC48aNER4ejqZNmyIiIgLx8fEAHk/wVigUCAwMhK+vLxYvXoyHDx8iKysLcXFxRZZSJeYrG/OVi/nKVdp8gccZnzp1Ci+99BKcnZ0Nz2VkZECn05X38Cs85isfM5aL+cr1NPm6uroWmlYAAAEBAbh//z4sLS2NMfxisZGrYnQ6HWrVqoW//voLQN41/w4ODpgyZQpiY2Px888/Q6PRGJ4DAEdHR3z44YeIjY3FihUrMHv2bIwYMQJHjhwx2nFUVMxXLuYrF/OV62nyVSgUEEIgPj4ejRs3BgCkp6dj0aJFGDlyJM6fP2+046iomK98zFgu5ivX0/6Oy/89p1QqodFosHfvXtSoUQNubm5GO4a/YyNXReR/GD08PBAXF2e4qWn+DSIbNWqEfv36Yf369UhJSTE8l6927dpo1KgRFi9ejJ9//hlDhw5Fhw4dyv9AKijmKxfzlYv5yvUs+QJ5ixJcvnwZL7zwAg4ePIiQkBCsWLECwcHBaN68uVGOpSJivvIxY7mYr1zP+jtOoVBAq9UiIyMDu3fvxo4dO9CzZ080aNDAaMdSRPlcwUkVRXZ2tvD39xfTpk0Ter1eCPF4vktiYqLw9vYW69atE0IIodfrhV6vF3/88Yfo1auXUKvVYuHChUYbuylgvnIxX7mYr1xPk68QQpw8eVKo1Wrh5+cnGjduLKZNm2aUcZsK5isfM5aL+cr1tL/jDh8+LKZMmSIGDhwomjVrJubPn2+0sZeE38hVEvnXQosn3E3C0tISAwcOxMaNGxEbGwvg8dfzjo6OeO211xAVFQUAMDMzg5mZGU6fPg0XFxfs378fH330kdwDqaCYr1zMVy7mK5eMfIG8Je5tbW3RokUL7N+/HxMmTJB3EBUY85WPGcvFfOWS9TsuOzsb2dnZePHFF7Fnzx6MGjVK7oE8AzZyJu78+fMYN24c9u3bB6Dw5U4FCSGQk5MDAOjWrRvc3NywYMECpKamGvaztraGmZkZ7OzsoNVqodfrAQChoaFYtGhRiffZqMyYr1zMVy7mK5esfPPnaLz00kvYuHEjFi5cCBcXl3I4ooqF+crHjOVivnLJzrdt27b4/PPPMXny5EKLyVQkbORMlF6vx9q1azFkyBDs2LED+/btM1zX+/czEnq9HgqFAmZmZnjw4AFcXFwQFhaGgwcPYsWKFcjMzASQd611amoqXF1doVKpDDcytLCwKN+DqwCYr1zMVy7mK5fsfPNXRKtZsybq169frsdWETBf+ZixXMxXrvLK19zcHLa2tuV7cE+JjZyJOnPmDNauXYvWrVtj8ODB2L59u2GVuL+fkcj/g2v27Nnw9fVFfHw8AgICMHr0aOzevRu9e/fGokWLEBYWhhs3buDNN98s9+OpaJivXMxXLuYrF/OVi/nKx4zlYr5yMd8C5E7Bo7KWPzkzLi5OfPXVVyIlJUUIIURwcLDo06ePuHr1qhDi8eRNIYTYs2ePaNKkiejSpYvYsGGDyM7ONjwXHR0tRo8eLQYPHixCQ0PFtWvXyvFoKh7mKxfzlYv5ysV85WK+8jFjuZivXMy3KDZyJiAxMVHExsaKR48elbjNiRMnhFqtFl9//bXQaDRCCCFycnKEEEIcOnRIzJw5U6SlpZW4/4MHD8p20CaE+crFfOVivnIxX7mYr3zMWC7mKxfz/WcKIZ6wxAsZjUajwZQpU7Bv3z5YW1vD0dERffv2xTvvvGPYJjc313Cvi5EjR+LChQuYO3cu7x9SCsxXLuYrF/OVi/nKxXzlY8ZyMV+5mG/pmBt7AFSyxYsXIzo6GnPnzsWDBw9w9OhRTJo0CTqdDt27d4eNjY3hZoZmZmaYNGkS2rVrh507d6JBgwaoUaOGsQ+hQmO+cjFfuZivXMxXLuYrHzOWi/nKxXxLydhfCVLx0tPTRWBgoJg/f36ha30nTpwo2rVrJ7Zs2VJo+/zrhufNmyd8fHzE/v37hRBCaLVaw9fM+dsQ85WN+crFfOVivnIxX/mYsVzMVy7mW3pctbKCsra2RmZmJlxdXaFQKKDVagEAn3/+OWrWrIlt27bh6tWrAB5/tQwAY8aMgY2NDSIjIxEdHY0ffvgBc+bMAZB3c0PKw3zlYr5yMV+5mK9czFc+ZiwX85WL+ZYeG7kK6t69e2jQoAGio6Oh1+uhUqmg0+lgaWmJoUOH4tq1a4YbICqVSiiVj/9Xjhw5Evv378eHH36I//znPxX+HhjGwHzlYr5yMV+5mK9czFc+ZiwX85WL+ZYeG7kKytnZGe7u7oiNjcXFixcBPD6b8NZbb6F+/fr4448/kJycbNhHq9Xi2LFjOHToEACgffv2OHjwIEaNGlX+B1DBMV+5mK9czFcu5isX85WPGcvFfOVivk/B2Nd2UskuXrwoGjduLBYuXGhYdlWr1QohhPjtt9+EWq0W169fN2x//fp1ERISIgIDA0V0dLQxhmxSmK9czFcu5isX85WL+crHjOVivnIx39JhI1fBjR07VgQEBIgDBw4IIR7f5DA9PV20atWq0IRPjUYjLly4YIxhmizmKxfzlYv5ysV85WK+8jFjuZivXMz3yXhpZQU3adIkAMDatWtx+fJlw4TOS5cuQafTwcXFBQAghIBKpUKTJk2MNlZTxHzlYr5yMV+5mK9czFc+ZiwX85WL+T4ZG7kKzs7ODmFhYbh58ybCw8Nx/PhxnD9/HlFRUfDw8ICHhwcAGD7c9HSYr1zMVy7mKxfzlYv5yseM5WK+cjHfJ1MIIYSxB0FPdvToUcyaNQspKSkQQsDOzg4RERFo0aKFsYdWKTBfuZivXMxXLuYrF/OVjxnLxXzlYr4lYyNnQrKyspCWlobbt2+jZcuWxh5OpcN85WK+cjFfuZivXMxXPmYsF/OVi/kWj40cERERERGRieEcOSIiIiIiIhPDRo6IiIiIiMjEsJEjIiIiIiIyMWzkiIiIiIiITAwbOSIiIiIiIhPDRo6IiIiIiMjEsJEjIiIiIiIyMWzkiIiIiIiITAwbOSIiIiIiIhNjbuwBEBERVSSbN2/GZ599VugxR0dHeHh4YOjQoWjXrp2RRkZERPQYGzkiIqJijBo1Cm5ubhBCIC0tDVu2bMHw4cOxbNkydOjQwdjDIyKiKo6NHBERUTECAgLQrFkzw7//9a9/wd/fHzt37mQjR0RERsc5ckRERKVQvXp1WFpawtw87xxoYmIi1Go1vvvuO6xcuRIdOnSAl5cXBgwYgMuXLxfZPy4uDqNGjULLli3RrFkz9OzZE3v37i20zebNm6FWq9G0aVOkp6cXeu706dNQq9VQq9WIiYkp9NzatWsRFBQEb29vwzZqtRq//PJLGadAREQVBb+RIyIiKsaDBw8MzVRaWhpWr16NrKwsvP3224W227p1Kx4+fIh+/fpBo9Fg9erVeO+997Bjxw44OTkBAK5cuYKQkBA4Oztj2LBhqFatGnbt2oURI0Zg4cKF6NSpU6HXVCqV2L59O95//33DY5s3b4alpSU0Gk2hbaOiovDFF1+gZcuWGDBgAKytrXHt2jUsW7ZMQipERFRRsJEjIiIqRsEmCgBUKhVmzJgBf3//Qo/fuHEDu3fvhrOzM4C8SzJ79+6Nb775xrBoyvTp0+Hq6opNmzZBpVIBAPr164eQkBDMmTOnSCPXqVMnbNq0yTCGR48eISoqCp06dcLOnTsLbbt3715Ur14d3377LSwtLQEAx44dYyNHRFTJ8dJKIiKiYkyaNAnff/89vv/+e8yePRutWrXChAkTsHv37kLbvf7664YmDgC8vLzg7e2N33//HQCQkZGBo0eP4q233jJ8y5eeno67d+/itddeQ3x8PFJSUgq95ttvv43r168bLqH83//+Bzs7O7Rp06bIOB8+fAgrKytDE0dERFUDv5EjIiIqhpeXV6HFToKCgtC9e3dMnToV7du3Nzz+wgsvFNm3fv362LVrF4C8b+yEEJg/fz7mz59f7HulpaUVagYdHR3Rrl07bNq0Cc2aNcOmTZvQvXt3KJVFz7/6+Phg//79WLhwIXr16gUrKytkZmY+62ETEZGJYCNHRERUCkqlEq1atcKqVauQkJAAa2vrUu2Xm5sLABg8eDDatm1b7Dbu7u5FHuvVqxc+/fRTDBw4ECdPnsT06dNx8uTJItu9//77uH79OpYsWYJFixY9xREREZEpYyNHRERUSjk5OQCArKwsQyOXkJBQZLv4+HjUrVsXAFCvXj0AgIWFBfz8/Er9XgEBAbC0tMSYMWPwyiuvwN3dvdhGzsrKCtOmTUNsbCzs7Ozw0Ucf4dKlS5g5c+ZTHx8REZkOzpEjIiIqBZ1Oh0OHDsHCwgIvvvii4fFff/210By3c+fO4ezZswgICAAA1KxZEy1btkRkZCRSU1OLvO7fbzOQz9zcHN26dcOff/6JXr16/ePY5s2bh9u3b2P27Nnw8/ODp6fnsxwiERGZEH4jR0REVIwDBw7g2rVrAPKarR07diA+Ph7Dhw+Hra0tMjIyAORdFhkSEoKQkBBotVqsWrUKNWrUwNChQw2vNXnyZPTr1w/BwcF45513UK9ePdy5cwdnzpxBcnIytm/fXuwYPv74YwwZMgT29vYljvPw4cNYuXIlZs2aZfgWkIiIKj82ckRERMVYsGCB4b8tLS3RsGFDTJkyBX379i20Xf4iJD/88APS0tLg5eWFiRMnonbt2oZtPDw8sGnTJixatAhbtmxBRkYGHB0d0aRJE4wYMaLEMahUKjg6Opb4/N27d/Hpp5+ia9euRe5vR0RElZtCCCGMPQgiIiJTk5iYiMDAQISFhWHIkCHGHg4REVUxnCNHRERERERkYtjIERERERERmRg2ckRERERERCaGc+SIiIiIiIhMDL+RIyIiIiIiMjFs5IiIiIiIiEwMGzkiIiIiIiITw0aOiIiIiIjIxLCRIyIiIiIiMjFs5IiIiIiIiEwMGzkiIiIiIiITw0aOiIiIiIjIxLCRIyIiIiIiMjH/Bw7BZamZpcF4AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 900x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "fig, ax = plt.subplots(figsize=(9, 4))\n",
+    "per_hour_plot = per_hour.reset_index(name='transactions')\n",
+    "sns.lineplot(data=per_hour_plot, x='event_time', y='transactions', ax=ax)\n",
+    "ax.set_title('Распределение транзакций по часам')\n",
+    "ax.set_xlabel('Время')\n",
+    "ax.set_ylabel('Количество транзакций')\n",
+    "plt.xticks(rotation=30)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b01c6d84",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.720262Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.719976Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.731857Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.730818Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Режим обработки</th>\n",
+       "      <th>Ожидаемая задержка, сек</th>\n",
+       "      <th>Комментарий</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Batch (каждый час)</td>\n",
+       "      <td>3600</td>\n",
+       "      <td>Слишком поздно для онлайнового антифрода</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Микробатчи (5 минут)</td>\n",
+       "      <td>300</td>\n",
+       "      <td>Допустимо для мониторинга, но не выполняет SLA...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Стриминг (&lt;50 мс)</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Требует событийной архитектуры</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Режим обработки  Ожидаемая задержка, сек  \\\n",
+       "0    Batch (каждый час)                     3600   \n",
+       "1  Микробатчи (5 минут)                      300   \n",
+       "2     Стриминг (<50 мс)                        2   \n",
+       "\n",
+       "                                         Комментарий  \n",
+       "0           Слишком поздно для онлайнового антифрода  \n",
+       "1  Допустимо для мониторинга, но не выполняет SLA...  \n",
+       "2                     Требует событийной архитектуры  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "batch_latency = 60 * 60  # сек\n",
+    "micro_batch_latency = 5 * 60\n",
+    "stream_latency = 2  # предполагаемый SLA на обработку true streaming\n",
+    "\n",
+    "latency_table = pd.DataFrame([\n",
+    "    {'Режим обработки': 'Batch (каждый час)', 'Ожидаемая задержка, сек': batch_latency, 'Комментарий': 'Слишком поздно для онлайнового антифрода'},\n",
+    "    {'Режим обработки': 'Микробатчи (5 минут)', 'Ожидаемая задержка, сек': micro_batch_latency, 'Комментарий': 'Допустимо для мониторинга, но не выполняет SLA 50 мс'},\n",
+    "    {'Режим обработки': 'Стриминг (<50 мс)', 'Ожидаемая задержка, сек': stream_latency, 'Комментарий': 'Требует событийной архитектуры'},\n",
+    "])\n",
+    "\n",
+    "latency_table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "788a04eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.734422Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.734114Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.746205Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.744888Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Показатель</th>\n",
+       "      <th>Значение</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Потерянные записи за 30 мин сбоя</td>\n",
+       "      <td>2,967</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Объём потерянных данных</td>\n",
+       "      <td>1.50 МБ</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Потенциальный ущерб (средний чек)</td>\n",
+       "      <td>262,121</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          Показатель Значение\n",
+       "0   Потерянные записи за 30 мин сбоя    2,967\n",
+       "1            Объём потерянных данных  1.50 МБ\n",
+       "2  Потенциальный ущерб (средний чек)  262,121"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "outage_minutes = 30\n",
+    "lost_records = per_second_stats['mean_rps'] * outage_minutes * 60\n",
+    "lost_volume_mb = lost_records * volume_stats['avg_bytes_per_row'] / 1024**2\n",
+    "lost_amount = lost_records * df['Amount'].mean()\n",
+    "\n",
+    "velocity_stats.update({\n",
+    "    'lost_records_30min': lost_records,\n",
+    "    'lost_volume_mb_30min': lost_volume_mb,\n",
+    "    'lost_amount_30min': lost_amount,\n",
+    "})\n",
+    "\n",
+    "loss_table = pd.DataFrame([\n",
+    "    {'Показатель': 'Потерянные записи за 30 мин сбоя', 'Значение': f\"{lost_records:,.0f}\"},\n",
+    "    {'Показатель': 'Объём потерянных данных', 'Значение': f\"{lost_volume_mb:.2f} МБ\"},\n",
+    "    {'Показатель': 'Потенциальный ущерб (средний чек)', 'Значение': f\"{lost_amount:,.0f}\"},\n",
+    "])\n",
+    "\n",
+    "loss_table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e5d30410",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.751124Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.750778Z",
+     "iopub.status.idle": "2025-09-18T11:03:20.762967Z",
+     "shell.execute_reply": "2025-09-18T11:03:20.762052Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Показатель</th>\n",
+       "      <th>Значение</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Пиковая нагрузка, событий/сек</td>\n",
+       "      <td>4.59</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Пропускная способность 1 воркера</td>\n",
+       "      <td>20.0 событий/сек</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Необходимое количество воркеров</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         Показатель          Значение\n",
+       "0     Пиковая нагрузка, событий/сек              4.59\n",
+       "1  Пропускная способность 1 воркера  20.0 событий/сек\n",
+       "2   Необходимое количество воркеров                 1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "limit_ms = 50\n",
+    "peak_rps = velocity_stats['peak_5min'] / (5 * 60)\n",
+    "service_capacity_per_worker = 1000 / limit_ms\n",
+    "headroom = 1.2  # 20% запас\n",
+    "required_workers = math.ceil((peak_rps / service_capacity_per_worker) * headroom)\n",
+    "\n",
+    "resource_table = pd.DataFrame([\n",
+    "    {'Показатель': 'Пиковая нагрузка, событий/сек', 'Значение': f\"{peak_rps:.2f}\"},\n",
+    "    {'Показатель': 'Пропускная способность 1 воркера', 'Значение': f\"{service_capacity_per_worker:.1f} событий/сек\"},\n",
+    "    {'Показатель': 'Необходимое количество воркеров', 'Значение': required_workers},\n",
+    "])\n",
+    "\n",
+    "velocity_stats['required_workers'] = required_workers\n",
+    "\n",
+    "resource_table\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b418cfb",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**Вывод по Velocity.** При среднем потоке ~1.65 события/сек и пиках до 4.6 события/сек режим batch или микробатч приводит к задержке от минут до часа. Для выполнения SLA 50 мс необходим true streaming-процессинг (Flink/Spark Structured Streaming) с минимум двумя воркерами (один + резерв) и буферизацией поздних событий через Kafka. Сбой в 30 минут потенциально стоит ~262 тыс. у.е., поэтому критичен контроль отказоустойчивости и репликации.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77e9bd1c",
+   "metadata": {},
+   "source": [
+    "## 3. Variety (разнообразие данных)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "78731368",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:20.765642Z",
+     "iopub.status.busy": "2025-09-18T11:03:20.765264Z",
+     "iopub.status.idle": "2025-09-18T11:03:21.140967Z",
+     "shell.execute_reply": "2025-09-18T11:03:21.139915Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Колонка</th>\n",
+       "      <th>Тип</th>\n",
+       "      <th>Уникальных значений</th>\n",
+       "      <th>Есть пропуски</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Time</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>124592</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>V1</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>V2</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>V3</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>V4</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>V5</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>V6</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>V7</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>V8</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>V9</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>V10</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>V11</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>V12</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>V13</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>V14</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>V15</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>V16</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>V17</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>V18</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>V19</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>V20</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>V21</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>V22</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>V23</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>V24</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>V25</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>V26</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>V27</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>V28</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>275663</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>Amount</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>32767</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>Class</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>2</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Колонка      Тип  Уникальных значений  Есть пропуски\n",
+       "0     Time  float64               124592          False\n",
+       "1       V1  float64               275663          False\n",
+       "2       V2  float64               275663          False\n",
+       "3       V3  float64               275663          False\n",
+       "4       V4  float64               275663          False\n",
+       "5       V5  float64               275663          False\n",
+       "6       V6  float64               275663          False\n",
+       "7       V7  float64               275663          False\n",
+       "8       V8  float64               275663          False\n",
+       "9       V9  float64               275663          False\n",
+       "10     V10  float64               275663          False\n",
+       "11     V11  float64               275663          False\n",
+       "12     V12  float64               275663          False\n",
+       "13     V13  float64               275663          False\n",
+       "14     V14  float64               275663          False\n",
+       "15     V15  float64               275663          False\n",
+       "16     V16  float64               275663          False\n",
+       "17     V17  float64               275663          False\n",
+       "18     V18  float64               275663          False\n",
+       "19     V19  float64               275663          False\n",
+       "20     V20  float64               275663          False\n",
+       "21     V21  float64               275663          False\n",
+       "22     V22  float64               275663          False\n",
+       "23     V23  float64               275663          False\n",
+       "24     V24  float64               275663          False\n",
+       "25     V25  float64               275663          False\n",
+       "26     V26  float64               275663          False\n",
+       "27     V27  float64               275663          False\n",
+       "28     V28  float64               275663          False\n",
+       "29  Amount  float64                32767          False\n",
+       "30   Class    int64                    2          False"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "dtype_summary = pd.DataFrame({\n",
+    "    'Колонка': df.columns,\n",
+    "    'Тип': [str(t) for t in df.dtypes],\n",
+    "    'Уникальных значений': df.nunique().values,\n",
+    "    'Есть пропуски': df.isna().any().values,\n",
+    "})\n",
+    "\n",
+    "dtype_summary\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "08621849",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:21.143606Z",
+     "iopub.status.busy": "2025-09-18T11:03:21.143335Z",
+     "iopub.status.idle": "2025-09-18T11:03:21.816177Z",
+     "shell.execute_reply": "2025-09-18T11:03:21.815117Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "- Все 31 полей — числовые (float/int), текстовых или полу-структурированных данных нет.\n",
+       "- Колонка `Time` хранит секунды с начала сбора без таймзоны; для feature engineering требуется перевод в календарные признаки.\n",
+       "- Колонки `V1`-`V28` — PCA-компоненты, название не несёт бизнес-смысла, важно сопровождать метаданными.\n",
+       "- Обнаружено 1081 дубликатов строк, что указывает на необходимость дедупликации до загрузки в витрины.\n",
+       "\n",
+       "Пример записи:\n",
+       "```json\n",
+       "{\n",
+       "  \"Time\": 0.0,\n",
+       "  \"V1\": -1.3598071336738,\n",
+       "  \"V2\": -0.0727811733098497,\n",
+       "  \"V3\": 2.53634673796914,\n",
+       "  \"V4\": 1.37815522427443,\n",
+       "  \"V5\": -0.338320769942518,\n",
+       "  \"V6\": 0.462387777762292,\n",
+       "  \"V7\": 0.239598554061257,\n",
+       "  \"V8\": 0.0986979012610507,\n",
+       "  \"V9\": 0.363786969611213,\n",
+       "  \"V10\": 0.0907941719789316,\n",
+       "  \"V11\": -0.551599533260813,\n",
+       "  \"V12\": -0.617800855762348,\n",
+       "  \"V13\": -0.991389847235408,\n",
+       "  \"V14\": -0.311169353699879,\n",
+       "  \"V15\": 1.46817697209427,\n",
+       "  \"V16\": -0.470400525259478,\n",
+       "  \"V17\": 0.207971241929242,\n",
+       "  \"V18\": 0.0257905801985591,\n",
+       "  \"V19\": 0.403992960255733,\n",
+       "  \"V20\": 0.251412098239705,\n",
+       "  \"V21\": -0.018306777944153,\n",
+       "  \"V22\": 0.277837575558899,\n",
+       "  \"V23\": -0.110473910188767,\n",
+       "  \"V24\": 0.0669280749146731,\n",
+       "  \"V25\": 0.128539358273528,\n",
+       "  \"V26\": -0.189114843888824,\n",
+       "  \"V27\": 0.133558376740387,\n",
+       "  \"V28\": -0.0210530534538215,\n",
+       "  \"Amount\": 149.62,\n",
+       "  \"Class\": 0.0\n",
+       "}\n",
+       "```\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "example_record = df.iloc[0].to_dict()\n",
+    "\n",
+    "variety_md = f\"\"\"\n",
+    "- Все {num_cols} полей — числовые (float/int), текстовых или полу-структурированных данных нет.\n",
+    "- Колонка `Time` хранит секунды с начала сбора без таймзоны; для feature engineering требуется перевод в календарные признаки.\n",
+    "- Колонки `V1`-`V28` — PCA-компоненты, название не несёт бизнес-смысла, важно сопровождать метаданными.\n",
+    "- Обнаружено {df.duplicated().sum()} дубликатов строк, что указывает на необходимость дедупликации до загрузки в витрины.\n",
+    "\n",
+    "Пример записи:\n",
+    "```json\n",
+    "{json.dumps(example_record, indent=2)}\n",
+    "```\n",
+    "\"\"\"\n",
+    "\n",
+    "display(Markdown(variety_md))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d662c843",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**Работа с разнообразием.**\n",
+    "- Неструктурированных данных нет, поэтому дополнительные NLP/гео-обработки не требуются.\n",
+    "- Для временных паттернов нужно агрегировать по окнам (5 мин, час, сутки) и обогащать внешними источниками (часы, праздники, региональные особенности).\n",
+    "- Схема хранения: сырые данные в Parquet (bronze), нормализованные фичи в Delta Lake (silver), агрегаты и фичи для модели — в Feature Store (gold).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "732dfc62",
+   "metadata": {},
+   "source": [
+    "## 4. Veracity (достоверность данных)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c3a29d05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:21.819327Z",
+     "iopub.status.busy": "2025-09-18T11:03:21.819012Z",
+     "iopub.status.idle": "2025-09-18T11:03:22.649348Z",
+     "shell.execute_reply": "2025-09-18T11:03:22.648190Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Метрика качества</th>\n",
+       "      <th>Значение</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Пропуски по колонкам</td>\n",
+       "      <td>31 / 31 колонок без пропусков</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Отрицательные суммы</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Дубликаты строк</td>\n",
+       "      <td>1081</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Доля мошенничества</td>\n",
+       "      <td>0.1727%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Метрика качества                       Значение\n",
+       "0  Пропуски по колонкам  31 / 31 колонок без пропусков\n",
+       "1   Отрицательные суммы                              0\n",
+       "2       Дубликаты строк                           1081\n",
+       "3    Доля мошенничества                        0.1727%"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "quality_table = pd.DataFrame([\n",
+    "    {'Метрика качества': 'Пропуски по колонкам', 'Значение': f\"{(df.isna().sum()==0).sum()} / {num_cols} колонок без пропусков\"},\n",
+    "    {'Метрика качества': 'Отрицательные суммы', 'Значение': (df['Amount'] < 0).sum()},\n",
+    "    {'Метрика качества': 'Дубликаты строк', 'Значение': df.duplicated().sum()},\n",
+    "    {'Метрика качества': 'Доля мошенничества', 'Значение': f\"{df['Class'].mean()*100:.4f}%\"},\n",
+    "])\n",
+    "\n",
+    "quality_table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d9dc265a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:22.653400Z",
+     "iopub.status.busy": "2025-09-18T11:03:22.652995Z",
+     "iopub.status.idle": "2025-09-18T11:03:22.811786Z",
+     "shell.execute_reply": "2025-09-18T11:03:22.807954Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/great_expectations/expectations/expectation.py:1487: UserWarning: `result_format` configured at the Validator-level will not be persisted. Please add the configuration to your Checkpoint config or checkpoint_run() method instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:   0% 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:   0% 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  33% 2/6 [00:00<00:00, 1199.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  33% 2/6 [00:00<00:00, 603.28it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  50% 3/6 [00:00<00:00, 693.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  50% 3/6 [00:00<00:00, 585.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  67% 4/6 [00:00<00:00, 565.12it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  67% 4/6 [00:00<00:00, 464.99it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 6/6 [00:00<00:00, 550.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 6/6 [00:00<00:00, 516.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 6/6 [00:00<00:00, 482.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 6/6 [00:00<00:00, 441.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/great_expectations/expectations/expectation.py:1487: UserWarning: `result_format` configured at the Validator-level will not be persisted. Please add the configuration to your Checkpoint config or checkpoint_run() method instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:   0% 0/8 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:   0% 0/8 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  25% 2/8 [00:00<00:00, 1523.26it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  25% 2/8 [00:00<00:00, 871.91it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  38% 3/8 [00:00<00:00, 921.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  38% 3/8 [00:00<00:00, 771.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  62% 5/8 [00:00<00:00, 317.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  62% 5/8 [00:00<00:00, 298.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 288.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 278.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 268.93it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 251.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/great_expectations/expectations/expectation.py:1487: UserWarning: `result_format` configured at the Validator-level will not be persisted. Please add the configuration to your Checkpoint config or checkpoint_run() method instead.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:   0% 0/8 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:   0% 0/8 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  25% 2/8 [00:00<00:00, 1680.75it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  25% 2/8 [00:00<00:00, 805.05it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  38% 3/8 [00:00<00:00, 840.37it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  38% 3/8 [00:00<00:00, 669.55it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  62% 5/8 [00:00<00:00, 288.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics:  62% 5/8 [00:00<00:00, 271.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 274.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 264.93it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 256.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Calculating Metrics: 100% 8/8 [00:00<00:00, 250.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Expectation</th>\n",
+       "      <th>Success</th>\n",
+       "      <th>Unexpected %</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>No nulls in Time</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Amount non-negative</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Class is binary</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Expectation  Success  Unexpected %\n",
+       "0     No nulls in Time     True           0.0\n",
+       "1  Amount non-negative     True           0.0\n",
+       "2      Class is binary     True           0.0"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "ctx = ge.get_context()\n",
+    "engine = PandasExecutionEngine()\n",
+    "batch = Batch(data=df)\n",
+    "validator = Validator(execution_engine=engine, batches=[batch], data_context=ctx)\n",
+    "\n",
+    "ge_results = {\n",
+    "    'No nulls in Time': validator.expect_column_values_to_not_be_null('Time'),\n",
+    "    'Amount non-negative': validator.expect_column_values_to_be_between('Amount', min_value=0),\n",
+    "    'Class is binary': validator.expect_column_values_to_be_in_set('Class', [0, 1]),\n",
+    "}\n",
+    "\n",
+    "ge_summary = pd.DataFrame([\n",
+    "    {\n",
+    "        'Expectation': name,\n",
+    "        'Success': result['success'],\n",
+    "        'Unexpected %': result['result']['unexpected_percent'],\n",
+    "    }\n",
+    "    for name, result in ge_results.items()\n",
+    "])\n",
+    "\n",
+    "ge_summary\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ac8321a",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**Воздействие проблем качества.** При ошибке меток даже на 1% (~2.8 тыс. транзакций) возможен рост FN и прямые потери >~0.6 млн у.е. Поэтому нужно:\n",
+    "- выполнять дедупликацию и контроль меток до поступления в real-time поток,\n",
+    "- ежедневно запускать data-quality проверки (Great Expectations + Airflow) и алерты на рост доли пропусков,\n",
+    "- логировать поздние события и пересчитывать фичи ретроспективно.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e92e997",
+   "metadata": {},
+   "source": [
+    "## 5. Value (ценность данных)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "5a448e1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:22.819667Z",
+     "iopub.status.busy": "2025-09-18T11:03:22.819215Z",
+     "iopub.status.idle": "2025-09-18T11:03:22.844166Z",
+     "shell.execute_reply": "2025-09-18T11:03:22.841962Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Показатель</th>\n",
+       "      <th>Значение</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Количество транзакций</td>\n",
+       "      <td>284,807</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Количество мошеннических транзакций</td>\n",
+       "      <td>492</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Сумма мошенничества (EUR)</td>\n",
+       "      <td>60,127.97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Цель (30%) — предотвращено, EUR</td>\n",
+       "      <td>18,038.39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Потенциальная выгода (RUB)</td>\n",
+       "      <td>1,803,839</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Годовые затраты, RUB</td>\n",
+       "      <td>1,707,729</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>ROI</td>\n",
+       "      <td>5.6%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Срок окупаемости</td>\n",
+       "      <td>11.4 месяцев</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            Показатель      Значение\n",
+       "0                Количество транзакций       284,807\n",
+       "1  Количество мошеннических транзакций           492\n",
+       "2            Сумма мошенничества (EUR)     60,127.97\n",
+       "3      Цель (30%) — предотвращено, EUR     18,038.39\n",
+       "4           Потенциальная выгода (RUB)     1,803,839\n",
+       "5                 Годовые затраты, RUB     1,707,729\n",
+       "6                                  ROI          5.6%\n",
+       "7                     Срок окупаемости  11.4 месяцев"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "total_transactions = len(df)\n",
+    "total_fraud = int(df['Class'].sum())\n",
+    "fraud_amount_total = df.loc[df['Class'] == 1, 'Amount'].sum()\n",
+    "reduction_target = 0.30\n",
+    "eur_to_rub = 100  # предположение о курсе EUR/RUB\n",
+    "potential_savings_rub = fraud_amount_total * reduction_target * eur_to_rub\n",
+    "\n",
+    "compute_cost_rub = 2 * 18 * 24 * 365  # два стриминг-воркера по 18 ₽/час\n",
+    "kafka_cost_rub = 6000 * 12  # управляемый кластер Kafka\n",
+    "storage_cost_rub = volume_stats['yearly_storage_cost_rub']\n",
+    "development_cost_rub = 2 * 220_000 * 3  # 2 инженера, 3 месяца\n",
+    "\n",
+    "annual_cost_rub = compute_cost_rub + kafka_cost_rub + storage_cost_rub + development_cost_rub\n",
+    "roi = (potential_savings_rub - annual_cost_rub) / annual_cost_rub\n",
+    "payback_months = annual_cost_rub / (potential_savings_rub / 12)\n",
+    "\n",
+    "value_table = pd.DataFrame([\n",
+    "    {'Показатель': 'Количество транзакций', 'Значение': f\"{total_transactions:,}\"},\n",
+    "    {'Показатель': 'Количество мошеннических транзакций', 'Значение': total_fraud},\n",
+    "    {'Показатель': 'Сумма мошенничества (EUR)', 'Значение': f\"{fraud_amount_total:,.2f}\"},\n",
+    "    {'Показатель': 'Цель (30%) — предотвращено, EUR', 'Значение': f\"{fraud_amount_total * reduction_target:,.2f}\"},\n",
+    "    {'Показатель': 'Потенциальная выгода (RUB)', 'Значение': f\"{potential_savings_rub:,.0f}\"},\n",
+    "    {'Показатель': 'Годовые затраты, RUB', 'Значение': f\"{annual_cost_rub:,.0f}\"},\n",
+    "    {'Показатель': 'ROI', 'Значение': f\"{roi*100:.1f}%\"},\n",
+    "    {'Показатель': 'Срок окупаемости', 'Значение': f\"{payback_months:.1f} месяцев\"},\n",
+    "])\n",
+    "\n",
+    "value_stats = {\n",
+    "    'potential_savings_rub': potential_savings_rub,\n",
+    "    'annual_cost_rub': annual_cost_rub,\n",
+    "    'roi': roi,\n",
+    "    'payback_months': payback_months,\n",
+    "}\n",
+    "\n",
+    "value_table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "68ca0243",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:22.849454Z",
+     "iopub.status.busy": "2025-09-18T11:03:22.849025Z",
+     "iopub.status.idle": "2025-09-18T11:03:23.135898Z",
+     "shell.execute_reply": "2025-09-18T11:03:23.134686Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqwAAAGACAYAAABoRDDgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAma9JREFUeJzs3Xd4VMXXwPHvpjcSCIQWSgiYEAglFCH0Kr2D9KKCoHRFAUWQn0CoKu2VIkqRqkiTJkW6IFWqICWUAEkgvSe79/0jZM2SQnKzaeR8niewO3fuvWd3drMns3NnNIqiKGRSvXr1GDx4MB9++CHBwcF4e3vz448/4u3tDcCmTZuYO3cuFy5cyOyhhRBCCCGEMGCiZqeYmBgcHR3T3B4ZGak6ICGEEEIIIZJTlbBWrFiRs2fPprn94MGDVKlSRXVQQgghhBBCJFGVsA4ePJg9e/awYsUKIiIiAFAUhfv37/PJJ59w6dIlhgwZYsw4hRBCCCFEAaVRM4YV4LvvvmPJkiUoioJOp8PExARFUTAxMWHs2LG8//77xo5VCCGEEEIUQKoTVoDHjx/z+++/c//+fXQ6HeXKleOtt96ibNmyxoxRCCGEEEIUYFlKWIUQQgghhMhuZtlx0MuXLzN//nz9/erVqzNhwoTsOJUQQgghhHjNqUpYJ0+enO72gIAAzp49y6xZswAoUaKEmtMIIYQQQgihbkiAl5dXutt1Oh1xcXHcuHFDdWBCCJGdIiIiCAkJwdHRERsbG9XHiY+PJzw8HDs7OywsLAgKCsLKyipLx8wOsbGxhISEYGZmRtGiRXP03FFRUYSGhmJjY4ODg0OOnlsI8XrIljGsx44dY/jw4ZKwCiHyDEVR2LJlC1u3buXmzZvExMQAMH36dPr06aP6uGfOnGHQoEEsXLiQtm3b4u7uTv/+/Zk6daqxQlft1KlTrF27lnPnzhEeHg5Ahw4d+Prrr7P93Hv37mXTpk1cvnyZqKgoAN5//30+/vjjbD+3EOL1ky1jWDUaTXYcVgij+vXXX5k8eTK//PIL1apVS7F94MCBBAcH89tvv+VCdMLYPv74Y/bs2UO3bt147733KFSoEBqNBnd39ywdt3Llyvz444/64/z444+ULFnSGCFnyfr165kxYwa1a9fm888/1w/NKl26dLafe/78+axcuZKWLVsyY8YMihQpgkajwcXFJdvPLYR4PWVLwiqEEHnJ9u3b2bNnD/PmzaNTp05GPbaDgwMNGjTQ309+O7f4+voye/Zs3n77bb788ssc7UT466+/WLlyJR9//LHMxy2EMBpVCWt6y7IC3Lx5U1UwQgiRHVatWkWHDh2MnqzmVevWrcPJyYkpU6bk+DdeP/zwA15eXpKsCiGMStXSrAMHDmTQoEFp/iSf0kqI182dO3cYM2YMb775JtWqVaN79+4cOnTIoM6vv/6Ku7s7V65cMSgPCgrC3d2dxYsX68sWL16Mu7s7QUFBBnWvXLmCu7s7v/76q0H5n3/+Sb9+/ahZsyZ16tThgw8+4M6dOyni9Pf357PPPqNRo0Z4enrSokULpk2bRlxcnD6+9H6Szjtp0qRXXmiZmlWrVuHu7o6fn1+KbQsWLMDT05PQ0FAgsUdw9OjRNGzYkGrVqtGkSRPGjx+vH3eZnr1799K9e3eqV69OvXr1mDBhAv7+/vrtUVFR3Lp1i1KlSvH+++9Tq1YtatasycCBAzl37py+3sGDB1M8By+3X2oy83rw9PRM0c4XL17M1PmuX7/O0KFDqVWrFl5eXgwePJhLly4Z1Ll06RJVq1Zl+vTpNGjQAE9PTzp27MiWLVsM6j169Ah3d3dWrVrF6tWrad68OdWrV2fAgAHcunXLoO4///zDpEmTaNmyJdWqVaNhw4ZMnjyZ4ODgFOd2c3Nj/PjxvPnmm1SvXp0ePXpw8ODBFI/l+fPnfPbZZzRo0IBq1arRuXNntm3bliK+9H4mTZoEQEhICHPmzKFTp054eXlRq1Ythg4dyj///GNwzjNnzuDu7s6+fftSxOPl5aU/HhjnfZxcixYt9MdXFIWBAwdSv359nj9/rq8TFxdHp06daNWqlX7sb3qSzvvyz8CBAw3qnTt3jjFjxtCsWTM8PT1p2rQps2bN0o/lTpLW+33fvn24u7tz5swZfdnAgQPp2LFjirpJ7/1Hjx4ZPPbhw4en+TiS2iXp+Hfu3KF69ep8+umnKR6Hh4cH8+bNS+dZEa8jVT2sCxcuTHf79evXWbFihaqAhMjL/v33X/r27UuJEiUYNmwYNjY27N27l5EjR7J48WJat26drec/deoUw4YNo0yZMowaNYqYmBh++ukn+vbty6+//kqZMmWAxGS1Z8+ehIeH8/bbb+Pq6oq/vz/79+8nJiaGunXrMnfuXP1xly1bBsCIESP0ZbVq1cpSrO3atWPevHns3buXoUOHGmzbu3cvDRs2xMHBgbi4ON577z3i4uIYMGAAxYoVw9/fnyNHjhAWFkahQoXSPEfSOORq1arx0Ucf8fz5c9auXcuFCxfYvn079vb2hISEALBy5UqcnJx47733sLS05Oeff2bIkCH8+OOP1K1bF09PT/1zcv78eTZv3vzKx5jZ14OJiQk7d+5kyJAhBo/B0tKS2NjYDJ2vf//+2NraMnToUMzMzNi8eTMDBw7kp59+okaNGkBi8nb16lXMzMzo168f5cqV4+DBg3zxxReEhISk6P3cvn07kZGR9OvXj9jYWNatW8fgwYPZtWsXxYoVAxJfew8fPqR79+44OTnx77//smXLFm7fvs2WLVv0PbkhISFs3rwZGxsbBg0aRJEiRdi5cyejRo1i/vz5+gQnJiaGgQMH8uDBA/r370+ZMmXYt28fkyZNIiwsjMGDB+Po6GjwOj1w4AAHDhwwKCtXrhwADx8+5ODBg7Rt25YyZcrw7NkzNm/ezIABA9i9e3eem15Ro9Ewa9YsOnfuzLRp01iyZAmQmID++++/rFu3LlMzTXz55Zf6+qldVLdv3z5iYmLo27cvhQsX5vLly/z00088ffqURYsWGedBGVHFihUZO3Ysc+fOpU2bNrRs2ZKoqCgmT56Mq6srY8eOze0QRU5TssGxY8eUypUrZ8ehhTCarVu3Km5ubsrly5dT3T5gwAClQ4cOBmWDBw9WOnbsqMTGxurLdDqd0rt3b+Wtt9565bGfP3+uuLm5KYsWLdKXLVq0SHFzc1OeP39uUPfy5cuKm5ubsnXrVn1Zly5dFG9vbyU4OFhfduPGDaVy5crKp59+qi/79NNPlcqVK6f62HQ6XaqPdcCAAak+DxMnTlRq1qyZ6rZX6d27t9KtWzeDsr///ltxc3NTtm3bpiiKoly/fl1xc3NT9u7dm6ljx8XFKd7e3krHjh2VmJgYffkff/yhuLm5KQsXLlQURVEePnyouLm5KVWrVlXu3bunr/f8+XPlzTffTBGforz6tZEks6+Hjz76SOnYsaO+PCoqSqlVq5by0UcfZeh8H374oVK1alXlwYMH+jJ/f3/Fy8tL6d+/v76sefPmipubm/Lrr7/qyxISEpTBgwcrnp6eSlBQkMFzU716deXp06f6ukltNGvWLH1ZdHR0inh+++03xc3NTTl79qy+zM3NTXFzc1POnDljsG+7du2Uhg0bKnFxcYqiKMrq1asVNzc3ZceOHfp6cXFxSu/evZWaNWsq4eHhKc6X9F5JTWxsrKLVag3KHj58qHh6eipLlizRl50+fTrN11vNmjWViRMn6u8b432cXPPmzQ2OryiKsmnTJv3zcOnSJcXDw0OZOXNmmsd42ddff624ubnp21RRFKVDhw4p3s+ptd/y5csVd3d3xc/PT1+W1vt97969ipubm3L69Gl9WWq/IxVFUb7//nvFzc1Nefjwob6sefPmyvvvv5/m40hql+TH12q1St++fZUGDRooQUFByvTp05UqVaq88n0iXk+qhgQIURCFhIRw+vRp2rVrR0REBEFBQQQFBREcHEyjRo3w9fU1+CoaMKgXFBSk/wo8NaGhoQZ1IyIiDLYHBARw48YNunXrRuHChfXllStXpkGDBhw9ehRInAf54MGDNG/ePNXZD9SOaUyKKyM9gUnatWvHtWvXePDggb5s7969WFhY0KpVKwDs7OwAOHHiBNHR0Rk+9tWrV3n+/Dl9+/bF0tJSX96sWTNcXV05cuSIQf2WLVsaXKXu6OhI9+7duXbtGs+ePUv1HEnt93JbgLrXQ+fOnbl3757+K+b9+/dTqFAhvL29X/l4tVotJ0+epFWrVpQtW1ZfXrx4cTp27Mj58+cN4ixWrBhdunTR3zc1NWXw4MHExcXx559/Ghy7VatWBj2Q1atXp0aNGvrXFICVlZX+dmxsLEFBQfoe3WvXrhkcr1q1arz55psG+/br14/AwECuX78OJE5/6OTkZPCVsrm5OQMHDiQqKuqV10q8zMLCAhOTxI80rVZLcHAwNjY2VKhQQX/O5CIjIw3eb+l9la/mfZyRr/MBevfuTaNGjZgxYwaffvopZcuW5aOPPsrQvoD+/Zj8PZCa5O0XFRVFUFAQXl5eKIqS6vPz8nMTGRmZ6nG1Wm2Kumm9jxMSEvTvkYSEhFc+NhMTE2bPnk1UVBTDhg1jw4YNvP/++6n+XhOvP5klQIgMevDgAYqisHDhwjSHxTx//tzggz/5V7+v0rZt23S3P378GIAKFSqk2FaxYkVOnDhBVFQUUVFRRERE8MYbb2T43K8SFRVlkFSVKlWKd955h8GDB6e7X9u2bZk9ezZ79uxhxIgRKIrCvn37aNKkiT5RLVu2LO+88w4//vgju3btok6dOrRo0YLOnTunOxwgvefD1dWV8+fPA/8l6K6urqnWA/Dz89N/9Z1c8vazt7enQ4cOfPrpp9jY2Kh6PTg6OtK0aVO2bt1KtWrV2Lp1K127dtUnWulJSgTSan+dTseTJ0/07e7i4pLiuBUrVgQwGFsIUL58+RTHdHFxYe/evfr7ISEhLFmyhD179hiMuQRSjDVO7blOOrefnx81atTAz8+P8uXLpxljUvtmlE6nY+3atWzYsIFHjx6h1Wr125L/gZfks88+y/Cx1b6PixYtSq9evRgzZgympqZp7jNr1ixatWpFaGgomzZtMkguXyU4OBhzc3Osra3Trff48WMWLVrE4cOHUyTcL/9B9vL7PT13797NcN0TJ07o65qamuLu7s7HH39Mo0aN0tynXLlyjBo1irlz5+Lm5saHH36YoXOJ14+qhNXLyyvdXhqdTqc6ICHyqqTX9bvvvkvjxo1TrZM0ni7J1KlTDRKMiIgIRo8eneq+ixcv1idxAPfu3eN///tfVsM2CktLS/0418jISLZu3cqsWbNwcnKiffv2ae5XokQJ6tSpw969exkxYgSXLl3i8ePHTJgwwaDepEmT6NatG4cOHeLkyZPMmDGD5cuXs2XLlizPaZqZD/+XJbVfXFwcZ86c4YcffgASxwuqeT0A9OjRg4kTJ+ov+po5c6bBxV/GkJXHnJZx48Zx8eJF3nvvPTw8PLCxsUGn0zF06FCUZOvPZMe5M2LZsmUsXLiQHj16MHbsWBwcHDAxMWHWrFkG8SUZOXIkderUMShLPoY7OTXv4+joaA4ePMiyZcuws7Nj2LBhacZ+5swZ4uLiALh161amLnL08/OjVKlS6X4ma7Va3nnnHUJDQxk6dCiurq7Y2Njg7+/PpEmTUnxmJ3+/Jzl37hxLly5NcWxnZ2dmzJhhULZv375Ux4DXqFGDcePGAYnfGK1cuZJRo0a9cq7rkydP6vcJCQnByckp3fri9aQqYW3Tpo0sDiAKnKSvYc3NzTM812b16tUNvr5K72vHOnXq4OjoqL//cu9i0oTv9+7dS7Hv3bt3KVKkCDY2NlhZWWFnZ8e///6boRgzwtTU1OAxN23alHr16nH8+PF0E1ZIHBYwffp07t69y549e7C2tqZ58+Yp6iVd3fzhhx9y4cIF+vbty8aNGxk/fnyqx03+fLzcw3Pv3j399qTnJa3nDRI/dFOTvP2aNWvGrVu3OH78OKDu9QDQpEkTLC0tGT9+PLVr16ZcuXIZSlgdHR2xtrZO83GYmJhQqlQpAMqUKcP169fR6XQGPZhJjzfp4rwk9+/fT3FMX19f/fMSGhrKn3/+yejRoxk1apRBnZeVKVMmQ8+1s7MzN2/eTDPGzC5wsH//furVq8esWbMMysPCwihSpEiK+m5ubinaLa1eULXv45YtW3LhwgWOHz+eZsIaEBDAjBkzaNSoEebm5syZM4dGjRql+ZpMLiEhgX/++SfNP5iS3Lp1C19fX+bMmUPXrl315UmJ4Mtefr9D4vOYGhsbmxR101rlskiRIgZ1y5UrR9++fTl37pz+tfuyjRs3cvLkScaPH8/y5cuZOnUq3333Xap1xetN1RjW2bNn4+Pj88ofIV4nRYsW5c0332Tz5s0EBASk2J7eh5gxFC9eHA8PD7Zv327w4XHr1i1OnjxJ06ZNgcRxX61ateKPP/5IdZqk1Hqb1Erva84kbdq0wdTUlN27d7Nv3z6aNWtmcPVzREREivFsbm5umJiY6HudUuPp6UnRokXZtGmTQb2jR49y584dmjVrBiQ+H40bN+bQoUM8fPhQXy8kJITt27fj6emZ6nCA1MTGxuofs9rXg5mZGV26dOHmzZv06NEjQ+eFxOe6YcOGHDp0yOAr/WfPnvHbb79Ru3ZtfQ9906ZNCQwMZM+ePfp6SV+ZW1hYpEjwDx48aDDe9vLly/z99980adJEf+7UrFmzJkVZkyZNuHz5MhcuXNCXxcbGsnHjRpycnKhataq+3ssxJiQk6K+Or1u3boafm6QYX35t7927N8U44pykKAqKoqT7Pvniiy/Q6XTMnDmT//3vf5iZmfH5559n6H168uRJwsPDadmyZbr1kv4gSH5MRVFYu3ZtBh9J9kjq2U1rSMzDhw/1swSMGDGCiRMncvjwYbZv356DUYq8QlUP699//60fbC9Efrd161Z9r1lyfn5+xMTE8H//93906dIFZ2dnpk2bRr9+/ejUqRNvv/02ZcuW5dmzZ1y6dImnT5+yc+fObI31008/ZdiwYfTu3ZuePXvqp7UqVKiQQc/XRx99xMmTJxk4cCBvv/02FStWJDAwkH379rFhwwbs7e0zdV6tVsuxY8eAxCEBv/76K1FRUfoLp9JTtGhR6tWrx48//khkZGSKHtnTp0/zv//9j7Zt2+Li4oJWq2XHjh2YmprSpk2bNI9rbm7OhAkTmDx5MgMGDKBDhw76aa2cnZ0Nxh2OHTuW48eP069fP/r164eFhQVbtmwhPDzcYN7Nlx07doy7d+8SFxfHX3/9xdmzZ3n33Xf129W+HsaOHct7772Hg4PDK5+/5MaNG8epU6f0j8PU1JTNmzcTFxfHJ598oq/Xs2dPNm7cyKRJk7h69SplypTh4MGD/Pnnn3z88ccpehyTerr69u1LXFwca9eupXDhwvrpyOzs7Khbty7ff/898fHxlChRgpMnT6YYCwswbNgwdu3axbBhwxg4cKB+Wqvbt28zf/58zMwSP3Z69+7N5s2bmTRpEteuXcPZ2Zn9+/dz4cIFPvvsM4PhMRnRrFkzli5dyuTJk/Hy8uLWrVvs2rXL4AK1nHD69Gns7OyIiYnhwIED3L9/P82x3lu3buXIkSPMnj1bP/RlypQpfPLJJ2zYsIH+/funeZ49e/YwZ84cLCwsiImJYceOHfpt4eHhaLVaDh48SKtWrXB1daVcuXLMmTMHf39/7Ozs2L9/f5q9ptklKChI/3skMDCQlStXUqhQIerVq5eit15RFD777DOsrKz48ssvAejTpw+///47M2fOxNvbO89NVSayl6qEtXfv3pQvX57OnTvTuXPnHP+FIIQxbdy4Md3tCxcupHbt2jg7O1OpUiW2bt3KkiVL2LZtGyEhITg6OlKlShVGjhyZ7bE2aNCA77//nkWLFrFo0SLMzMyoW7cun3zyicH7sESJEmzZsoWFCxeya9cuIiIiKFGiBE2aNFE1xjA2Nlb/lWbSlddz587V92K+Svv27Tl16hS2trb6nuAk7u7uNGrUiD/++AN/f3+sra1xd3dn5cqV1KxZM93jdu/eHSsrK1auXMn8+fOxsbGhVatWfPLJJwZJecWKFVm/fj0LFixgxYoVKIpCtWrVmDlzZopxjMklzU9pbm5O6dKlGTlypME4R7WvBwsLC4PhHxn1xhtv6B/H8uXLURSF6tWrM2/ePINOBEtLS9auXcv8+fPZvn07ERERVKhQgRkzZtCrV68Ux0268GvNmjU8f/6c6tWr88UXX1C8eHF9nQULFvDVV1+xYcMGFEWhYcOGrFy5MsXX0Y6OjmzcuJF58+bx008/ERcXh5ubG0uWLDH4A8fKyop169Yxf/58tm3bpo/Rx8eH7t27Z/q5GTFiBNHR0ezatYs9e/ZQpUoVli9fzoIFCzJ9rKxIGsJiZWVFmTJlmDx5cqqJ59OnT/Hx8aF58+Z069ZNX965c2d+//135s+fT5MmTdL8fJ0/fz5Pnz4F4PPPP0+1TtLFXObm5ixbtkw/NtzS0pLWrVvTv39/g5kkstvly5f1v0eKFClC1apVmTNnDiVKlEiRsK5bt46//vqLxYsXG7xXZs6cSceOHfniiy9kvvcCRqOo+H5w165d7Nq1i1OnTqHVaqlRowZdunShXbt2qV6NKUR+9ejRI1q2bMnatWupV69ebocjhFElvb4//fRT3nvvvdwOR2RCixYtGDVqVJrJ/ZkzZ5g8eTKHDx/O4ciEyB6qxrB26tSJFStWcOzYMf1fdtOnT6dx48Z8+OGH7Nu3L92xZ0IIIYQQQmRUluZhdXR0ZMCAAQwYMIAHDx7oe17Hjx9PoUKFaNOmDV26dEn3Kzch8jJ7e3tGjBiR6SuWhRAiO7Vq1SrVadOSFCtWLENjzIXIL1QNCUiNv78/u3fvZseOHdy8eRMHBwdMTU0JDg6mSpUqzJkzh0qVKhnjVEIIIYxAhgQIIfKLLCWsERER7N+/n127dnH27Fk0Gg1NmjSha9euNG/eHBMTEw4cOMCcOXMoVqwYP//8szFjF0IIIYQQBYCqIQEHDx5k165dHDlyhNjYWKpVq8Znn31G+/btU0yX0rZtW8LCwvLMij1CCCGEECJ/UZWwjho1ilKlSjFkyBC6dOmS6rrRyVWuXJlOnTqpClAIIYQQQhRsqoYEnDlzRqb4EUIIIYQQOcJoF10VBBcvXkRRFMzNzXM7FCGEEEKIfC0+Ph6NRoOXl9cr66qah7WgSloXOifOExcXlyPnEkagKPDkCYqfH8qLtbFF3ifvs/xH2iz/kTbLf3KyzTKTV2VpHtaCJqlntVq1atl6nqioKG7cuEGlSpWwsbHJ1nMJI4iMhBfLYkYFBGDj5JTLAYmMkPdZ/iNtlv9Im+U/OdlmV65cyXBd6WEVQgghhBB5miSsQgghhBAiT5OEVQghhBBC5Gmqx7BqtVp27tzJkSNHePz4MQClS5emefPmdOrUCVNTU6MFKYQQQgghCi5VCWt4eDjvvfceV65cwdbWlrJlywJw6tQpfv/9dzZu3MiqVauws7MzarBCCCGEEKLgUTUk4JtvvuHatWtMmTKFP//8k23btrFt2zZOnTrFF198wdWrV/nmm29UBXT//n2mTp1Kly5dqFKlCh07dszQfoqisGLFCpo1a0b16tXp3bs3ly5dUhWDEJml2NigtbLK7TCEEEKI15KqhPXAgQP07duX/v37G0yib25uTr9+/ejbty/79+9XFdC///7L0aNHKV++PBUrVszwfitXrmTRokUMGTKE5cuX4+TkxLvvvsvDhw9VxSFEhtnaEh0YyKUTJ8DWNrejEUIIIV47qhLWkJAQKlSokOb2ChUqEBoaqiqgFi1acPToURYtWkTVqlUztE9sbCzLly/n3XffZciQIXh7e/P1119TuHBhVq1apSoOIYQQQgiRN6hKWMuXL8/hw4fT3H748GHKlSunLiCTzId04cIFIiIiaNeunb7MwsKC1q1bc+zYMVVxCCGEEEKIvEHVRVd9+/blq6++YtiwYQwePBgXFxcA7t27x7p16/RjWXPK3bt3AXB1dTUor1ixImvWrCEmJgYrGV8osktMDJbdu1MpIgJ27gRZzUWIAitxqUlQEu+gJP7HixL9NuXFDf1t/f4p9025PZ19X7X9pW3JV8VUXpwz7WMn357OvknnAWJiYrgfEItiHYylZVTKfZPdz9ixk4783/Oa5r4pjp3Gvi8fJ9VjJ2/Ll9on2XOasWMnfy2ksm+6x062b7LbxpSQkEBxmzg8jHvYLFOVsPbv35+goCBWrFjBiRMnDA9oZsbIkSPp16+fUQLMiLCwMCwsLLC0tDQot7e3R1EUQkNDjZawKopCVFSUUY6VlujoaIP/RR4XGYnN/v04AM8jIkD+OMoX5H32H51OIUGrIy5BR0JC4v/xBj9a4rUK8fHaxPtaHQlaBa1OQadL/F+r1SX+r1PQapOV6/4rTzxP0jZdKnUTbyvJPuwV/Yd34jliYmOxOBSMRmOC7sUnte5FNqAzSBQS//+vDqAo+jqJ9xO3JyUGqZ0zKRnQJwcv/kme0OXAkuuvgcDcDkBkQjknCxrVyf7fjYqioNFoMlRX9Tyso0ePpn///vz555/4+fkB4OzsjLe3N46OjmoPm+fFx8dz48aNHDmXr69vjpxHZI1JdDReL24/ePAAXaD8Ys5P8vr7TKcoxMYrxMTpiInXERevJCaPCUpiYqm/nfh/fIJCnFb33+0EhYQXiWKCVkGrxeB+gk5Bp8vtR5lZ8bkdQJ6R/LNe8+IfjcE2jf5+ym3/7aOvmUqdlMfWGO6f5rE1htvSPbYm9dgy+pjSPLYRHpPB/po09s/gY0r1/JpXxPbf437VeY1Bo4EqZW1y7HejhYVFhuqpTlgBHB0d6dChQ1YOYRT29vbExcURGxtr0MsaFhaGRqPBwcHBaOcyNzenUqVKRjteaqKjo/H19cXFxQVra+tsPZcwgshI/c1y5cphXaxYLgYjMiqn32eKohAVk0B4VDxhUXGER8UTHhlP+IvbYVFxREQlEBUTT2RMApHR8UTFJBAVm5CjPXgaDZibmWBuZoKFmQlmpiaYm5libqbB3Mw0sczMBDNTDaYmGkxNTDA10WBiosFUX6bRl5mZmiRuS7pvosHE9L/9ktdN+l/z4oNeo0lMEDQvPpzj4+MJCPCnZMkSWFpaGmzT39bvq8FEA2jA5MUnusmLyv/dT2U/k8QEIqks6TlJSkAAfWzw336pJR6apDKN4T5JyVHypMYgWTE45ktJksbwfl4nn2f5T0622e3btzNcV1XC2qZNGyZOnEiLFi3U7G50SWNX7927R+XKlfXld+/epXTp0kYdv6rRaLDJoTGK1tbWOXYukQXJsglps/wnq22mKArhUfEEBEURGBJNUFhM4k9ojP52aEQsYZFxaHXqM08Lc1NsrcywsjTDysIUS3NTrCzMsLQwxdIi8bbVi9sG981NsXjx818iaoq5ebLbSeXmppi+SBjzoqioKG7cCMPDw1neZ/mM/G7Mf3KizTLzu0ZVwnr//n0ik/Uq5bZatWphZ2fH3r179QlrfHw8v//+O02aNMnl6IQQ+V1EdDxPnkUQEBSNf1AUgcFR+AdHERAURUBwFNGx2gwfy8rCFHtbi8QfO8v/bttaUMjGAlsrc2ytzbGzMcfW6r//LcxluWshRMGVpSEB2SE6OpqjR48C4OfnR0REBPv27QPgzTffxNHRkcGDB/P48WMOHDgAgKWlJcOHD2fx4sU4Ojri5ubGxo0bCQkJ4b333su1xyKEyD/i4rU8eR7J48AIHgVE8DgwEr/ACB4/iyA0Iu6V+xcpZIlTEWuKOljjaG9l8ONgZ4GDnSWFbC2wlMRTCCEyLc8lrM+fP2fs2LEGZUn3165dS7169dDpdGi1hj0aw4YNQ1EUfvjhB4KCgvDw8GDVqlWULVs2x2IXQuR98Qk6/AIjuOUbyMXroew8d5FHzxJ7TdMbK1qkkCUlHG0o7miT+H+R/247FbaWHlAhhMhGqhPW7BrjVKZMGW7evJlunXXr1qUaz/Dhwxk+fHi2xCVEmmxtiYqM5MaNG3jI0qx5hqIoBIZEc/9JGL5Pwrj/JJz7T8N4FBBOgjZ5Zhquv2VjZYazkx3OTnaUdrLD2ckWZyc7ShWzxcbKPOVJhBBC5AjVCevnn3/O1KlT09yu0Wg4f/682sMLIUSGaXUKD56GcetBMHf8QvF9HMaDp2FExiSkWt/a0oyyJWwpZJFAjcplqVSuKGWLF8LBziLPXnAkhBAFmaqEtVu3bsaOQwghMiwkPJbr955z834wtx4Gc/thCDFxKS98MjXR4FzcDpeS9pQvZY/Lix+nItZER0cn9op7lJWrl4UQIo9TlbD6+PgYOw4h8q+YGCwGDMA1LAy2bJGlWbNBUFgMV+884+qd51y9+4yH/hEp6lhbmvJG2SK8UbYwLqUSE9Qyxe0wN5OxpUIIkd/luYuuhMh3tFrMtm2jCBClzfj0RiJtOp3CrQfBnLn2lDPXnvLQPzxFnfIlC1HZxRH3ckVwK1+EMsULYWoiX+cLIcTrSHXCGhERwerVqzly5AiPHz8GoHTp0jRr1owhQ4ZgZ2dntCCFEK+/mLgE/r4VyJlrTzl73Z+QiFj9No0GKpR2wLNiUTxdi1HVtSj2thlbzk8IIUT+pyph9ff3p3///jx69AhXV1dq1aoFJK40tWTJEnbs2MH69espXry4UYMVQrxeYuISOHfDn+OX/Dh3I4C4+P96qG2szKhTuQRvVi1J7crFsbORBFUIIQoqVQnr/PnzefbsGcuXL6dp06YG244ePcq4ceNYsGABc+bMMUqQQojXR3yClvP/BHD8kh9/XXtqcLFU8SLWvFm1JPWrlqKKa1HMzUxyMVIhhBB5haqE9fjx4wwePDhFsgrQtGlTBg4cyJYtW7IcnBDi9aDVKfx9K5CjFx9x5uoTg+mmijva0LhGaRrVdKais4NMKyWEECIFVQlrdHQ0RYsWTXN7sWLFiI6OVh2UEOL18Dw0mt/PPOD3M/d5FvLf74SiDlY0quFM45qlcStXRJJUIYQQ6VKVsFasWJHdu3fTp08fLCwMx5XFx8eze/duKlasaJQAhRD5i1ancPFmAPv+9OXs9afoXiwqVcjGnMY1nWniVQYPF0dM5Ip+IYQQGaQqYR02bBjjx4+nV69e9OvXDxcXFyDxoqtNmzZx8+ZNvvnmG2PGKUTeZWNDVEAAN2/exL0Az8H6PDSaA38l9qYGBv/Xm1rVtSht65enQfXSWJjLnKhCCCEyT1XC2q5dO6Kjo1mwYAHTpk3Tf52nKApFixZl1qxZtG3b1qiBCpFnaTRga4vO2jrxdgGSXm9qizrlaFO/PGVLFMrdIIUQQuR7qudh7d69O507d+bq1asG87B6enpiZibrEQjxOpPeVCGEEDkpS5mlmZkZNWvWpGbNmkYKR4h8KDYWi/ffp3xoKKxd+9ouzWrQm3rDH92L7lTpTRVCCJHdVCWsZ8+ezVC9unXrqjm8EPlLQgJm69dTDIhKSHhl9fxGelOFEELkNlUJ68CBA9OdhkZRFDQaDTdu3FAdmBAi96TVm2pnbU6LumVpW99FelOFEELkGFUJ68KFC/W3IyIi+Pzzzxk5ciRubm5GC0wIkfOkN1UIIURepCphbdOmjf52cHAwAHXq1MHb29s4UQkhcoz0pgohhMjr5HJ+IQqo9HpT29QvT0PpTRVCCJFHSMIqRAGS1Ju6/7Qvf11P2Zvapl55ypW0z+UohRBCCENGS1hlLXAh8q7nodEcfNGbGpCsN7VKBUfaervQoHppLKU3VQghRB6lKmH18vJKkaCOGDECExMT/X2NRsP58+ezFp0Q+YGNDVG+vvz777+8kYfmYJXeVCGEEK8L1RddSY+qEC9oNODkRMKzZ3liadbg8BgOnHnA/tO+0psqhBDitaAqYZ09e7ax4xBCZIGiKNzwDWL3yXucuvyYBG2y3tQ6ZWlTX3pThRBC5F9y0ZUQWRUbi/n48ZQNDobly3N0adbo2ASOXHjEnpP38H0Spi93L1+E9g1caFjDWXpThRBC5HuqEtbt27dnqF7Xrl3VHF6I/CUhAfMVKygORC1dmiOnfOgfzp5T9zh87iFRMYnLwVqYm9LUy5n2DStQqUzhHIlDCCGEyAmqEtZJkyah0WhQlMSvHZPfTqLRaCRhFcKIdDqF8//4s/PYXS79G6gvL1XMlvYNKtCqblnsbCxyMUIhhBAie6hKWH/55Rf97fDwcN555x2mTZtGtWrVjBaYECJRdGwCh84+YNfxuzx+FgmAiQbqVilJ+4YVqPmGEyYmuX+xlxBCCJFdVCWsnp6e+ttJS7O6uLgYlAshsubp80h2n7zHgTP3iXzxtb+tlRmt65WnYyNXSjjmnSm0hBBCiOwkF10Jkcf84xvEr0duc+bqE15MnYqzky2dGrnSom45rC3lbSuEEKJgkU8+IfIARVE4/08Avxz+l2t3n+vLvdyc6NykIrXci8vX/kIIIQosVQlrSEiI/nZoaCgAkZGRBuUAhQsXVhuXEAWCVqvjxN+P2frHv9x7nDgtlZmphua1y9KlaUXKy9ypQgghhLqEtX79+ilWuho9enSKejdu3FAXlRD5ibU10devc/v2bSpaW2dol/gELQf/esDWP27jHxQFgJWFKW29XejSpCLFCmfsOEIIIURBoCphHTlypCzNKkQSExOU8uWJi4oCE5N0qyZodRw6+4DNB28R+GLZVHtbCzo3dqV9wwoUkmmphBBCiBRUJayp9aYKIdKm1er44/wjNh24qe9RdbS3pGcLN1rXK4eVhQwnF0IIIdJilE/J8PBwbGxsMDWVJSBFARQXh/lnn+EcFASLFhkszarVKRy/+IiNv9/Uz6Fa2M6Sni3foK23iyybKoQQQmSA6oT1ypUrfPvtt5w7d474+HhWrVqFt7c3QUFBfP755wwZMoR69eoZM1Yh8qb4eMwXLqQkELVggb74ws0Aftx1Dd8niRdTFbKxoGeLSrRvUAErmZpKCCGEyLBXfmrGxsayYcMG2rVrR8mSJQG4cOECgwcPpkSJEnTu3Jmff/5ZX9/R0ZGIiAg2b94sCasokO4/CeOH365x4Z8AAGytzenRvBIdGlbAxso8l6MTQggh8p9XJqxRUVHMmTOHypUr6xPWb775hooVK7JlyxYiIiIMElaAevXqsW3btuyJWIg8bMPv/7Lr0jN0OgUzUw0dGrrSu7WbXEwlhBBCZMErE9bChQtz6NAhnJyc9GVXrlzho48+wsLCItXZAkqUKMGzZ8+MG2keoSgKcXFxmJub6x+7VqtFq9ViYmKCmdl/T2lcXBxApusm0Wq1xMXFpagbHx+PoiiYmZlh8uKqdJ1OR0JCAhqNxuAYeaFuQkICOp0OU1NT/TjnzNRVFIX4+HgALCwssqVuam2U0boJcXGYmppiptWy78xDdOZW1KtSjIHtq1CuZGGjvk5Se94zUze/vU6ys+3j4uJISEggOTWvE2O977P7dZLf2j6tukm/Fy0tLfPN74jcbvvcfJ0k0el0xMXF5avfEcZ6neS33xFJj0VNG6mpm9FZp9Kfg+fFiUJCQgx+sZuZmaHT6dLcx9/fHxsbdeuc37lzh3feeYeaNWvSsGFD5s6dq2+E9AQHBzN16lSaNWtGzZo16dixIxs3blQVQ3pCQkLw8fEhKipKX3by5El8fHzYs2ePQd358+fj4+OjX1wB4OzZs/j4+LBz506DugsXLsTHx4fAwEB92dWrV/Hx8eGXX34xqLt06VJ8fHx48uRJirqbNm0yqLty5Up8fHx48OCBvuzWrVv4+Piwbt06g7qrV6/Gx8eH27dv68vu3buHj48Pq1atMqi7fv16fHx8DObaffToET4+Pixbtsyg7pYtW/Dx8eHKlSv6soCAAHx8fFi8eLFB3W3btuHj48P58+f1ZUFBQfj4+PD1118b1P3tt9/w8fHh9OnT+rLw8HB8fHyYM2eOQd39+/fj4+PD8ePH9WWxsbH4+Pjg4+Nj8Ho+dOgQPj4+HDp0SF+m0+n0dWNjY/Xle/cfYvaiRexv0waA4kWs+XJYfZTHh1m9YhHh4eH6uqdPn8bHx4fffvvNILavv/4aHx8fgoKC9GXnz5/Hx8cnxTcVixcvxsfHh4CAAH3ZlStX8PHxYcuWLQZ1ly1bho+PD48ePdKX3bhxAx8fH9avX29Qd9WqVfj4+HDv3j192e3bt/Hx8WH16tUGddetW4ePjw+3bt3Slz148AAfHx9WrlxpUHfTpk34+Phw9epVfdmTJ0/w8fFh6dKlBnV/+eUXfHx8uHTpkr4sMDAQHx8fFi5caFB3586d+Pj4cPbsWX1ZaGgoPj4+zJ8/36Dunj178PHx4eTJk/qyqKgoFi5cyL59+wzqHjx4EB8fH44cOaIvi4+P17d98l/kR44cwcfHh4MHDxocI6luTvyOuHTpUoH7HXHp0iUWLlyYb35HHD9+HB8fH/bv329wvjlz5uDj41NgfkcktX1++h2R1J7JFYTfES+/prLzd8TLC06l55UJa1hYGD179uTvv//Wl9WoUSPFmy9JVFQUv/76K3Xr1s1wEElCQ0MZPHgw8fHxLF68mPHjx7NlyxZmz579yn3Hjh3L4cOHGTNmDN999x2NGzfmyy+/TPEGFcIYFEXhwJn77P3T16B81vA3qV25RO4EJYQQQrymNIqiKOlViIuLY/fu3TRu3JhixYoB8PfffzNgwAC8vb3p0KEDEydOZNKkSdja2rJq1SqePn3Kpk2bqFy5cqaCWb58OcuWLeOPP/7QL+u6efNmpk+fzh9//EGJEqknAoGBgTRq1AgfHx+6d++uLx8wYACmpqasWbMmU3Gk5cqVKyiKQuXKlbO1Kz86OpobN27g5uaGpaVlgfq6Ly99jZNW3ahYHUt/+ZvTV5+iQUeN0tZMm9gRM62WqIAAbJycCszXffl5SEBoaCg3b96kWrVq+m+ECsLXffml7VOrGxUVxdWrV3Fzc6NQoUJ59ndEXmv73HydxMTEcOPGDdzd3fXDCPPL74iCOiQgOjqa27dv4+HhgY2NTba+Tm7cuIFGo6FatWq8yivHsFpYWNCtWzeDsho1arBixQq+/PJLJk6cCKDvBS1XrhwrVqzIdLIKcOzYMby9vfXJKkC7du2YNm0aJ0+eNEhGk0sarlCoUCGDcjs7O4Mud2PQaDQGL17A4IWb3Mv11NRNrTx5gycxMTHJs3WTv0nU1E3tOc/Ouqm1UVLdczf8WbjpIiERsZiZahjYzpMujV2Ja3qam3fvUuHF0qzGaPvU6qb2vGembn57nWR327+8LauvE8i+ts/q6yS/tX1adZN+LyZ/3Hnpd0RG6oL8jlBTNy98PhSE3xEvj+3PzrbPzKqpqieD9Pb2Zv/+/dy4cQNfX18URaFs2bJ4enqqXrb17t279OjRw6DM3t4eJycn7t69m+Z+pUqVolGjRixbtowKFSpQsmRJjh07xsmTJ1OMVRFCjfgEHWv3XGf70TsAlC9ZiI/716ZCaQcAlCpViNFoXrk0qxBCCCEyL8uzl3t4eODh4WGMWAgLC8Pe3j5FuYODg8GA49QkjXnt0KEDkPhXxZQpU2jz4mIYY1EUxei9ti+Ljo42+F/kroDgaBZuucLtR4mvwXbe5ejXuhIW5qb614K0Wf4jbZb/SJvlP9Jm+U9OtllmZgnIluV2jh8/zvvvv6+/36hRoxRXBhqToihMnjwZX19fFixYgJOTE6dOnWLWrFk4ODjok1hjSBpzkRN8fX1z5DwibTceRrPjdBAx8QpW5hq6ejtSuYyOO7f/u/pVEx9PyR9+oBRw/913UVL5SkTkXfI+y3+kzfIfabP8J6faLLXhAqlRlbC2bNky3e1JU3okTeVgZWWVoePa29sbTPGRJDQ0FAcHhzT3O3LkCPv27WPnzp24u7sDiYsXPH/+nNmzZxs1YTU3N6dSpUpGO15qoqOj8fX1xcXFBesXYyJFzopP0LF+/y32nn4OQKUyDozrXQ2nwqm0R2QkNi/+ILOcMgXrFxcnirxN3mf5j7RZ/iNtlv/kZJsln/7qVVQlrJUqVUq3CzcoKIjnz5/j7OycqeO6urqmGKsaHh5OYGAgrq6uae53+/ZtTE1NcXNzMyj38PDg559/Jjo62mhPukajUT3HbGZZW1vn2LnEf54+j2TO2nP6IQDdmlViUHsPzEzTGJ+abKINabP8R9os/5E2y3+kzfKfnGizbL/oavny5eluP3bsGMOHD8/0cZs0acKyZcsMxrLu27cPExMTGjZsmOZ+zs7OaLVabt68aTA7wbVr1yhatKj8VScy7Pw//sz/6TwR0fEUsjFnfN9a1K1SMrfDEkIIIQq0bBnDqnaWgD59+rBu3TpGjhzJ8OHD8ff3Z+7cufTp08dgDtbBgwfz+PFjDhw4ACQmuqVLl2bMmDGMHDmS4sWLc+LECbZt28bo0aON8pjE602nU/j58C3W7/sHRQH3ckWYOKguTkXkjx0hhBAit2VLwqqWg4MDa9as4auvvmLkyJHY2trSs2dPxo8fb1BPp9Oh1Wr19+3s7Fi9ejXffPMN8+fPJzw8nDJlyjBp0iQGDBiQ0w9D5DMxsQl8vfECf15JXKKurbcL73f1xNws5dx1QgghhMh5qhLWJUuWpLs9+XqzmVWxYsUU6xK/7OW1awHKly/Pt99+q/q8omAKCovhq1Wnuf0oFDNTEz7oUZ236pXP7bCEEEIIkUy2JKygfliAEDnF90kY078/zbOQaOxtLZjyTj08KjjmdlhCCCGEeImqhPXPP/985faPP/5YVUBC5ISrd57xv1VniI5NwNnJjmlD61OqmK26g1lZEXPsGPfu3aN8BqdwE0IIIUTGqUpYixQpku72QoUKqQpGiJxw/h9/Zq0+S1y8Fs+KRfl8yJvY2WRs4uJUmZqiq12bKBsbSGXNZiGEEEJkTZ666EqI7Hbq8mPm/XSOBK1CHY8STB5cFwtzSTKFEEKIvExVwnrt2rV0t9+/f19VMEJkp8PnHrJw80V0OoVGNUrzUb/amJulsRhAZsTFYfbNN5QICIDp00EmxxZCCCGMSlXC2qNHj3QvqlIURS66EnnKvj99WfrL3wC0qluOUW/XxNTESK/R+HgspkyhDBA1ZYpxjimEEEIIPVUJq4+Pj7HjECLb7P3Tl/97kax2bFSBYV2qYWKsZFUIIYQQ2U5VwtqtWzdjxyFEtkierHZtWpF3O1WV3n8hhBAinzHCAD4h8iZJVoUQQojXg+pZAmJjY9m/fz/Xr18nPDwcnU5nsF2j0TBr1qwsByiEGpKsCiGEEK8PVQmrn58fgwYNws/PD3t7e8LDw3FwcCA8PBytVkuRIkWwkSulRS6RZFUIIYR4vagaEjB37lwiIiLYsmUL+/btQ1EUvvnmGy5evMiECROwsrJi1apVxo5ViFc6+Nd9SVaFEEKI14yqhPX06dP07duX6tWrY2Ly3yEsLCwYOnQo9evXl+EAIsed+NuPxVsuAdC5iWvOJatWVsTs3cvNZctAlmYVQgghjE5VwhoTE4OzszMAdnZ2aDQawsPD9du9vLw4f/68cSIUIgPO3fBn/k/n0SnQpn55hnb2zLmeVVNTdE2aEFGnjizNKoQQQmQDVQlrqVKl8Pf3B8DMzIwSJUpw6dIl/fbbt29jaWlplACFeJUrt5/hs/ovtDqFJl7OfNCjhgwDEEIIIV4jqi66ql+/PocOHWLUqFFA4rysK1asICwsDJ1Ox86dO+nSpYtRAxUiNbceBPPVD6eJS9BRr2pJxvetZbwVrDIqPh6z5ctxevoUPvssZ88thBBCFACqEtb333+fK1euEBcXh4WFBSNGjCAgIID9+/djYmJCx44dmTx5srFjFcLA48AIpn9/muhYLTXeKManA+tgZpoLUwvHxWHx0UeUA6ImTMj58wshhBCvOVUJa+nSpSldurT+vqWlJTNnzmTmzJlGC0yI9ISEx/LlytOERcZRqYwDn79TDwtzGT8qhBBCvI5ULxyQRFEUgoKCAHB0dJSxgyLbxcQm8L9Vp3nyPJKSRW2YOrQ+1pZZfikLIYQQIo9S/Sl/+/ZtFi1axPHjx4mJiQHAysqKxo0bM2rUKNzc3IwWpBBJtDqFuT+d49+HIRSyseDLYd4UKSRTSQkhhBCvM1UJ67lz5xg2bBg6nY6WLVvi4uICwL179zh8+DDHjh3j+++/p06dOsaMVQjW7bnO2ev+WJiZMHVoPZyd7HI7JCGEEEJkM1UJ66xZs3B0dOSnn36iVKlSBtuePHlC//798fHxYevWrUYJUgiAoxcesfWP2wCM6e1F5fKOuRyREEIIIXKCqkuqb9++Tb9+/VIkq5A4R2vfvn25fft2loMTIsnthyEs2nwRgB7NK9G0VplcjkgIIYQQOUX1LAFxcXFpbo+Pj6dkyZKqgxIiueDwGGb+eIa4BB11PEowsH2V3A7JkKUlMVu38vDhQ5xlwQwhhBDC6FT1sI4cOZJ169Zx48aNFNuuX7/OTz/9xOjRo7McnBDxCTp8Vp/lWWgMzk52TOhfO+cXBngVMzN0bdsS1qgRmMlsBUIIIYSxqfp0/fvvvylatCjdu3fHy8uL8uXLA+Dr68ulS5d44403uHTpksFyrQBTpkzJcsCi4FAUheXbLnPDNwhbKzOmvPsmttbmuR2WEEIIIXKYqoT1p59+0t++cOECFy5cMNh+69Ytbt26ZVCm0WgkYRWZsu9PX/afvo9GAxMG1KFM8UK5HVLq4uMxXbeOok+eQKVKuR2NEEII8dpRlbD+888/xo5DCAO3HgSzYvtVAAa286COR4lcjigdcXFYjhiBCxA1cmRuRyOEEEK8dnJh4XUh0hcaEYvPmrMkaHV4VytFzxZv5HZIQgghhMhFWbpCJDg4mCJFigDw/Plztm7dSlxcHM2bN6dq1apGCVAULFqdwvyfzvMsJBpnJ1vG9fGS5X6FEEKIAk5Vwvrvv/8yfPhwnjx5QuXKlfn2228ZMGAAgYGBACxbtoxly5bRqFEjowYrXn8b9v/DpX8DsbQwZfKQN7GxkoushBBCiIJO1ZCA+fPnExoayvvvv09cXBzDhw/H2dmZ48ePc+DAAcqVK8d3331n7FjFa+7M1SdsOZh4sd7oXjUpX9I+lyMSQgghRF6gKmH9+++/eeeddxg/fjwzZszA19eXQYMG4eTkRNmyZXn77bdlpSuRKY+fRfDNxsTZJjo1dpWVrIQQQgihpyphDQkJoVy5cgD6OViTxrICODo6EhYWZoTwREEQE5eAz+qzRMYk4OHiyDsdZfyzEEIIIf6j+qIrE5PEXDfpghi5MEaooSgK3229jO+TMArbWTJxUB3MzfLZ5BWWlsSuW8cjPz9KydKsQgghhNGpTli/++47tmzZQkJCAgCzZ8/G3j5xzOHz58+NE5147e3705fD5x5iYqLh04F1KOpgndshZZ6ZGdru3Qm5cYNSsjSrEEIIYXSqPl3r1q0LJPaOmZqaGtyHxCEBjo6ORgpRvK5uPwzRLw4wuH0VqlUqlssRCSGEECIvUpWwrlu3zthxiAImKiaeuT+d0y8O0K1ZxdwOSb2EBEx//ZXCfn7whixyIIQQQhibqsGCZ8+eJSgoyNixiALku18v8+RZJE5FrBnzds38PQY6NhbLgQOpOGkSxMbmdjRCCCHEa0dVwjpo0CBOnjxp7FhEAXH43AOOnH+EiYmGCf1rY2djkdshCSGEECIPU5WwJo1VFSKz/AIj+G7rZQD6tXGnSoWiuRyREEIIIfK6PDd/0J07d3jnnXeoWbMmDRs2ZO7cucTFxWVoX39/fyZOnEj9+vWpXr067dq1Y+fOndkcscio+AQtc9edIyZOS/VKxejZwi23QxJCCCFEPqB6Dp4tW7Zw6tSpNLdrNBpmzZqVqWOGhoYyePBgXFxcWLx4Mf7+/syePZuYmBimTp2a7r4BAQH07t2bChUq8NVXX2FnZ8e///6b4WRXZL81u29w1y8Ue1sLPupXC1OTfDxuVQghhBA5RnXCevv2bfz8/NLcruYimk2bNhEZGcmSJUsoXLgwAFqtlunTpzN8+HBKlCiR5r7z5s2jZMmSfP/995iamgLg7e2d6RhE9vj7ViA7jt0BYFwfr/w536oQQgghcoXqhPWzzz6jU6dOxoyFY8eO4e3trU9WAdq1a8e0adM4efIk3bt3T3W/iIgI9u7dy6xZs/TJqsg7IqLj+XbTBQDaebtQt0rJXI5ICCGEEPlJnhrDevfuXVxdXQ3K7O3tcXJy4u7du2nud+3aNeLj4zEzM2PAgAFUrVqVhg0bMm/ePOLj47M7bPEKy7dd5lloDKWK2fJup6q5HY7xWVgQu2wZvtOmgYXMeCCEEEIYW55aRzIsLEy/vGtyDg4OhIaGprnfs2fPAJgyZQpvv/02o0aN4vLlyyxatAgTExM+/vhjo8WoKApRUVFGO15qoqOjDf7Pz/686s+R84/QaODD7lXQaeOIinr9xhVH9+zJc19fCiUkQDa/PoRxvE7vs4JC2iz/kTbLf3KyzRRFyfAQUlUJ66hRo3B3d1eza7bQ6XQANGjQgEmTJgFQv359IiMj+eGHHxg5ciRWVlZGOVd8fDw3btwwyrFexdfXN0fOk13CorQs3+MPQOMqhdBGPOHGjSe5HFX2yu9tVhBJm+U/0mb5j7RZ/pNTbWaRwW8mVSesycXExABkOSm0t7cnPDw8RXloaCgODg7p7geJSWpy3t7eLFu2jPv37xstwTY3N6dSpUpGOVZaoqOj8fX1xcXFBWvr/HlxkqIo+Ky9SHScjgqlCzG815uYmeapESjGk5BAwu7d+AcE4NinD9aFCuV2RCIDXof3WUEjbZb/SJvlPznZZrdv385wXdVDAh4/fszixYs5evQowcHBABQpUoSmTZsyatQonJ2dM31MV1fXFGNVw8PDCQwMTDG2NblXJZCxRlwuU6PRYGNjY7Tjpcfa2jrHzmVse07d4+/bz7EwM2FC/zrYF7LL7ZCyT2Qk9OuHPRDVr1++bbOCKj+/zwoqabP8R9os/8mJNsvMjFKqurzu3LlDt27d2LFjB1WqVGHQoEEMGjSIqlWrsmPHDnr06JHuRVJpadKkCadOnSIsLExftm/fPkxMTGjYsGGa+zk7O+Pm5pZiXthTp05hZWWV7T2iwpBfYASrdl4DYHCHKpQrmXJcshBCCCFERqnqYV2wYAEmJiZs27YtxVftt27dYsiQISxYsIClS5dm6rh9+vRh3bp1jBw5kuHDh+Pv78/cuXPp06ePwRysgwcP5vHjxxw4cEBfNn78eD788ENmzpxJs2bNuHLlCj/88APvvfee/FWXg7RaHV9vOE9cvJYabxSjY6O0e8aFEEIIITJCVQ/r2bNnGThwYKrjQt3c3Ojfvz9//fVXpo/r4ODAmjVrMDU1ZeTIkSxYsICePXvqL6RKotPp0Gq1BmUtWrTg66+/5s8//2T48OFs2bKF0aNHM27cuEzHIdTbdeIetx6EYGtlxtjetTCR1ayEEEIIkUWqelgTEhLSvcDK2tqahIQEVQFVrFiR1atXp1tn3bp1qZa3b9+e9u3bqzqvyLrnodFs2J84g8I7nTxxKiID7IUQQgiRdap6WD08PPj5559TvaI/IiKCX375hSpVqmQ5OJG/fL/jKtGxWiqXL0LrN8vldjhCCCGEeE2o6mEdPXo0w4YNo127dnTv3h0XFxcA7t27x7Zt2wgJCWHq1KnGjFPkcZduBXDi78eYaOCDHjVkKIAQQgghjEZVwurt7c2KFSuYO3cuK1asMNjm4eHBvHnzUsyJKl5fWp2inxWgfcMKuDqnPWfua8nCgrivv+bp06cUk6VZhRBCCKNTPQ9rgwYN2L59O4GBgTx+/BiA0qVL4+TkZLTgRP5w5PxDfJ+EYWtlRt+3Kud2ODnP3JyE4cMJvHGDYubmuR2NEEII8dpRnbAmcXJykiS1AIuN1/LT3sQLrd5u5Ya9rfQwCiGEEMK4smWtzJ07d+Lh4aH/+fTTT7PjNCIP2HnsDs9CY3AqYl1w51zVajE5dgy7c+fgpenWhBBCCJF1qnpYW7Zsme726OhoAA4ePAggE/e/pkIjYvnl8L8ADGzngYW5aS5HlEtiYrBq1w53IKp7dyhUKLcjEkIIIV4rqhJWPz8/PDw8DFafSs7f35/g4GCcnZ2zFJzI2zYfvEVUTAKuzg409SqT2+EIIYQQ4jWlegzru+++S6dOnVLdtmPHjhSrU4nXy+NnEew5eQ+AdztWlWmshBBCCJFtsmUMq0Yjycvrbu2eG2h1CrUqF6eGm1x0J4QQQojso7qH1c/Pj+vXr2NpaYmdnV2awwPE6+fe41BO/v0YjQaGdJAVzYQQQgiRvVQnrAsXLmThwoX/HcjMjKpVq9KyZUssZPL019qmAzcBaFTDmQqlC9giAUIIIYTIcaoSVh8fHwASEhKIjY0lODgYPz8/rl69yoIFC2RIwGvs3uNQTl1+gkYDvVu75XY4QgghhCgAVCWs3bp1S3Pb7du3GT9+PLdv32bJkiUAVK5cmVatWqmLUOQpmw/cAqBh9dKUL2mfy9HkEebmxM2YQUBAAI6y0pUQQghhdEa/6KpSpUpMnDiROnXqcObMGc6cOcOdO3eMfRqRC3yfhHHycuIyvH1au+dyNHmIhQUJ48fjP2gQyHAYIYQQwuiyvDRraho1akSjRo2y49AiFyWNXW1YozTlS0nvqhBCCCFyRpYSVn9/f86ePcvz589p06YNJUuWRKvVEh4eTqFChTA1LaArH72G7j8J45T0rqZOq8Xk/Hls7t0DNxnXK4QQQhibqoRVURRmz57N+vXrSUhIQKPR4ObmRsmSJYmKiqJFixaMGTOGIUOGGDlckVs2HbiJokCD6qVwkd5VQzExWDVpggcQ1a6dLM0qhBBCGJmqMazff/89a9eu5d133+XHH39EURT9tkKFCvHWW2/x+++/Gy1IkbsePJWxq0IIIYTIPaoS1p9//pmuXbvy0UcfUbly5RTb3d3d8fX1zWpsIo/Y+sdtFAW8q5WSeVeFEEIIkeNUJaxPnjzBy8srze3W1tZERESoDkrkHQHBURy98AiAni3eyOVohBBCCFEQqUpYixYtypMnT9Lcfu3aNUqVKqU6KJF37Dh6B61OoXqlYriVK5Lb4QghhBCiAFKVsLZu3ZpNmzbx8OFDfVnS6lYnTpxg27ZttG3b1jgRilwTFhnH/jP3AeghvatCCCGEyCWqZgkYM2YMZ86coUuXLtSpUweNRsPKlStZuHAhly5dwsPDgxEjRhg7VpHDdp+8R2ycFldnB7zcnHI7HCGEEEIUUKp6WAsVKsSWLVsYOnQo/v7+WFpacvbsWcLDwxk5ciQbNmzA2tra2LGKHBQTl8BvJ+4C0KN5JX0PukiFuTnxn33G42HDQJZmFUIIIYxO9cIBVlZWfPjhh3z44YfGjEfkEQf/ekBYZBwlHG1oWL10boeTt1lYEP/55zy5cYPCsjSrEEIIYXRZXpr1+fPn+Pn5AeDs7EzRokWzHJTIXTqdws7jib2r3ZpVwtRUVUe8EEIIIYRRqE5Y//zzT+bNm8eNGzcMyj08PJgwYQINGjTIcnAid1y8FcCTZ5HYWpnRok7Z3A4n79Pp0Fy/jtXdu+AuCysIIYQQxqYqYT1w4ABjx46laNGiDB06FBcXFwDu3bvHjh07GDZsGN9++y2tW7c2Zqwih/x24h4ALd8sh7VlljvhX3/R0VjXrUtVICogAOzscjsiIYQQ4rWiKhv59ttveeONN1i/fj12L304jxgxgr59+0rCmk89eRbJ+X/8AejQoEIuRyOEEEIIoXKWgIcPH9K9e/cUySqAnZ0dPXv25NGjR1kOTuS8PafuoShQq3JxSjtJT6EQQgghcp+qhNXV1ZWgoKA0tz9//lw/TEDkHzFxCRz46wEAHRtK76oQQggh8gZVCesnn3zCpk2bOHjwYIptBw4cYPPmzUycODHLwYmcdfSCH5HR8ZQsakOtyiVyOxwhhBBCCEDlGNZ169ZRpEgRRo8eTfHixSlXrhwADx48ICAgABcXF9auXcvatWv1+2g0Gr777jvjRC2MTlEUdp9MnMqqfYMKmJrIQgFCCCGEyBtUJay3bt0CoFSpUgD6eVhNTU0pVaoUsbGx+jpJZKWkvO3fhyHcexyGhZkJrd4sl9vhCCGEEELoqUpYDx8+bOw4RC77/cx9ABrUKE0hG1mtKVPMzYkfO5bnQUHYy9KsQgghhNHJJJuCmNgEjl1M7CV/683yuRxNPmRhQfysWfjduIG9LM0qhBBCGJ2qhPXx48cZqle6tKxBnx+c+Psx0bEJlCpmi2dFWVpXCCGEEHmLqoS1RYsWGRqT+vKyrSJvOvBX4nCA1m+Wk7HGauh0aO7fx+LxY1maVQghhMgGqocEtG/fnqpVqxozFpELHgWEc/1eECYaaFGnbG6Hkz9FR2NdpQrVkKVZhRBCiOygOmFt1qwZnTp1MmYsANy5c4cZM2Zw8eJFbG1t6dKlC+PGjcMiE2MDV69ejY+PD82aNWP58uVGj/F1cuBM4kIBdTxKUtTBOpejEUIIIYRIKU9ddBUaGsrgwYNxcXFh8eLF+Pv7M3v2bGJiYpg6dWqGjhEYGMjSpUspWlTGYr5KglbH4XMPAWhdT6ayEkIIIUTelKcS1k2bNhEZGcmSJUsoXLgwAFqtlunTpzN8+HBKlHj16kvz5s2jRYsWGb4wrCA7f8OfkIhYihSypI6HrGwlhBBCiLxJ1dKskD0LARw7dgxvb299sgrQrl07dDodJ0+efOX+586d4+DBg3z88cdGj+11dPTFVFZNa5XBzFT1S0EIIYQQIlup7mFdsGBBuuNDNRoNO3fuzNQx7969S48ePQzK7O3tcXJy4u7du+nuq9Vq+eqrrxgxYgTFixfP1HkLoujYBM5cewpAEy/nXI5GCCGEECJtqhLWunXrGjsOAMLCwrC3t09R7uDgQGhoaLr7btiwgejoaIYMGZItsSVRFIWoqKhsPUd0dLTB/9nh+N9PiIvXUqqoDaUdLbL9Mb3WoqKweXEzOjoa5LnMF3LifSaMS9os/5E2y39yss0URcnwN/aqEtZ169ap2S3bPH/+nEWLFjFnzpxMzSagRnx8fI7NL+vr65ttx95/6hkAbqVM+eeff7LtPAWBJi6OMr16AfDIzw8lMDCXIxKZkZ3vM5E9pM3yH2mz/Cen2iyjeVueuujK3t6e8PDwFOWhoaE4ODikud/ChQtxd3enTp06hIWFAZCQkEBCQgJhYWHY2NhgZmach2pubk6lSpWMcqy0REdH4+vri4uLC9bWxp9qKjwqjrtPE8evdmlRDWcnW6Ofo6CJ/u67bG0zYXzZ/T4Txidtlv9Im+U/Odlmt2/fznDdPJWwurq6phirGh4eTmBgIK6urmnud+/ePc6ePZvqUIW6deuycuVKmjRpYpQYNRoNNjY2r65oBNbW1tlyrmN/B6DVKbiWduCN8k5GP35Bll1tJrKPtFn+I22W/0ib5T850WaZuYA/TyWsTZo0YdmyZQZjWfft24eJiQkNGzZMc7/PPvtM37OaZNasWVhZWfHRRx/hLstlGjh68REgF1sZjaJAYCBmwcGJt4UQQghhVHkqYe3Tpw/r1q1j5MiRDB8+HH9/f+bOnUufPn0M5mAdPHgwjx8/5sCBAwB4eHikOJa9vT02NjbUq1cvx+LPD56HRnPt7nMAGkvCahxRUdi4uFCDF0uz2soQCyGEEMKY8tTkmw4ODqxZswZTU1NGjhzJggUL6NmzJ5MmTTKop9Pp0Gq1uRRl/nb8kh+KAlUqOFK8iHw9I4QQQoi8L0/1sAJUrFiR1atXp1snI7MU5LWZDPKKpMUCmniVyeVIhBBCCCEyRlXCGhISkqF6yVesErnvcWAEtx+GYGKioVGN0rkdjhBCCCFEhqhKWOvXr5+hK7tyar5SkTFJvas133DCwc4yl6MRQgghhMgY1UMCWrVqpb/6Pioqih9++IEuXbpQtmxZowUnjEdRFI69mB2gaS252EoIIYQQ+YfqhPWtt96iU6dOAAQHB/PDDz/QtWtXvL29jRacMJ57j8N4FBCBhZkJ9T1L5XY4QgghhBAZpmqWADMzMxISEvT3k24fOnRIrt7Po45eSOxdrVOlBDZW5rkczWvGzIyE/v151rEjGGlFNSGEEEL8R1XCWrJkSS5evKi/f+HCBQB++eUX+vbty4MHD4wTnTAKnU7h2CWZHSDbWFoSt2IF97/8EixlbLAQQghhbKoS1latWrFlyxbef/99PvnkEyZNmkTNmjXZtWsXAF26dOHnn382aqBCvRu+QTwLicba0ow6HiVevYMQQgghRB6i6vvLMWPGEB0dzeHDh4mMjKRWrVr873//w9nZmY0bN7J48WKmT59Or169jB2vUCHpYivvaqWwNDfN5WheQ4oCkZGYREfL0qxCCCFENlCVsNrY2DB9+nSmT5+eYpupqSnjxo2jcePGWQ5OZJ1Wq+Pk5ccANJXhANkjKgqb4sXxQpZmFUIIIbJDti3NWrt27ew6tMiEK3eeERoRRyEbC6q/USy3wxFCCCGEyDRVPayPHz/OUL3SpWU1pdx24u/EtmpQvRRmptn294kQQgghRLZRlbC2aNFCVrrKB7RaHX9eeQIgS7EKIYQQIt9SPWlkr1698PLyMmYswsiu3HlGWGQc9rYWVKsowwGEEEIIkT+pTljr1q2rX+lK5E3/DQcojakMBxBCCCFEPiVZzGsqQavj1OUXwwGqy3AAIYQQQuRfqntYDxw4wMOHD7GwsMDGxgYnJydcXV2pWLGiMeMTKl25/YzwqDgc7CzwrFg0t8N5vZmaktCtG+FhYViayjy3QgghhLGpTlh///13fv/9d4MyjUaDk5MTo0ePlkUDcpl+OEA1GQ6Q7aysiPvpJ+7euIGHlVVuRyOEEEK8dlQlrP/88w8AWq2W+Ph4wsLCePbsGbdv32bPnj1MnToVW1tb2rdvb9RgRcYkJJsdoKHMDiCEEEKIfC5LXW+mpqZYWVlRvHhxqlSpQufOnVm2bBkNGzZk9erVRgpRZFbScIDCdpZ4uspwACGEEELkb6qHBKRn3LhxnD59OjsOLTLgzLWnANTzLCnDAXJCZCQ2dnbU5sXSrDY2uR2REEII8VrJloTV09MTT0/P7Di0eAVFUf5LWKuWzOVohBBCCCGyTnXCGhERwerVqzly5Ih+qdbSpUvTrFkzhgwZgp2dndGCFBl31y+UZyHRWFqYUv0Np9wORwghhBAiy1R9X+zv70/Xrl1ZsmQJUVFR1KpVi1q1ahEdHc2SJUvo1q0bAQEBxo5VZEBS72ot9+JYmssUS0IIIYTI/1T1sM6fP59nz56xfPlymjZtarDt6NGjjBs3jgULFjBnzhyjBCkyLilhfbOKDAcQQgghxOtBVQ/r8ePHGTx4cIpkFaBp06YMHDiQo0ePZjk4kTkBwVHc9QvFRAN1q5TI7XCEEEIIIYxCVcIaHR1N0aJpT5dUrFgxoqOjVQcl1PnrRe9qZRdHHOwsczkaIYQQQgjjUJWwVqxYkd27dxMXF5diW3x8PLt375YlWnPBf7MDlMrlSAoYU1O0bdoQ2rAhyNKsQgghhNGpGsM6bNgwxo8fT69evejXrx8uLi4A3Lt3j02bNnHz5k2++eYbY8YpXiEyOp6rd54BifOvihxkZUXsr79yW5ZmFUIIIbKFqoS1Xbt2REdHs2DBAqZNm4ZGowES5wAtWrQos2bNom3btkYNVKTv/D/+JGgVyhS3w9lJphQTQgghxOtD9Tys3bt3p3Pnzly9etVgHlZPT0/MzLJlPQKRDlksQAghhBCvqyxllmZmZtSsWZOaNWsaKRyhRoJWx/kb/oCMX80VkZFYFy9OTZ2O2AcPZGlWIYQQwsiypSv04MGD+Pj46O+3bt2aSZMmZcepBHD1zjMiYxIobGeJW/kiuR1OgaSJikIutxJCCCGyh6qEddCgQeluf/78OY8fP2bNmjUA6U6BJbIuaThA3SolMDXR5HI0QgghhBDGpSph/euvvyhZsiSFChVKdXtkZCQAb775pvrIRIZdvBkIyGIBQgghhHg9qR4S8PHHH9OpU6dUt+3YsUOGAOSQ56HR+AVGoNFAtYrFcjscIYQQQgijU7VwwKskTXMlst/l24lzr1Z0dsDOxiKXoxFCCCGEMD7VCWt0dDShoaHExMQYMx6RSZf/TUxYa7zhlMuRCCGEEEJkD9VDAqZNm8a0adMSD2Jmpp+DtWXLlsTHxxstQJE2RVH4+3bi+NXqlSRhzTUmJmgbNyYqMhJTk2z50kIIIYQo0FQlrKNGjQIgPj6euLg4goOD8fPz49ixY+zZswcLC/lqOic8fR5FYHA0piYaqlRwzO1wCi5ra2L37ePWjRt4WFvndjRCCCHEaydLCevLtFotJ06cYNq0afj7+7N9+3YAypYtS+3atVUHKVJ3+UXvqnv5IlhZyupiQgghhHg9GfX7S1NTU5o2bcqnn35KqVKlWLRoEYsWLeLAgQPGPI14IWn8qgwHEEIIIcTrLFu65dq3b0/79u1V7Xvnzh1mzJjBxYsXsbW1pUuXLowbNy7dYQYBAQGsXr2akydP8uDBAwoVKkTdunX56KOPcHZ2Vvsw8jRFUbhyJylhlemsclVkJNYuLlRPSCD+1i1ZmlUIIYQwsjz1PXJoaCiDBw/GxcWFxYsX4+/vz+zZs4mJiWHq1Klp7nft2jUOHDhAjx49qFGjBsHBwXz33Xf06tWL3377DUfH1298Z2BwNMHhsZiaaGQ51jxA8+wZ5oBcbiiEEEIYX55KWDdt2kRkZCRLliyhcOHCQOK42OnTpzN8+HBKlEh9JafatWuzd+9ezMz+ezi1atWiWbNmbN++nXfffTcnws9RNx8EA+BS2h5Lc1nFXgghhBCvrzw1B8+xY8fw9vbWJ6sA7dq1Q6fTcfLkyTT3s7e3N0hWAUqWLImjoyMBAQHZFW6uuvUiYXUrJ72rQgghhHi95amE9e7du7i6uhqU2dvb4+TkxN27dzN1rHv37vH8+XMqVqxozBDzjJv3ExNWd0lYhRBCCPGay1NDAsLCwrC3t09R7uDgQGhoaIaPoygKM2bMoHjx4nTo0MGYIaIoClFRUUY95suio6MN/n9ZglbHHb8QAMoVt872eMQrREWRdJlVdHQ0SHvkC696n4m8R9os/5E2y39yss0URUGj0WSobp5KWI1l8eLFnD59mu+//x4bI1+xHR8fz40bN4x6zLT4+vqmWv4kKI64eB2W5hpCAu8T9ixjjS2yh0l0NF4vbj948ABdYGCuxiMyJ633mci7pM3yH2mz/Cen2iyji02pSlhnzJiRoXpTpkzJ1HHt7e0JDw9PUR4aGoqDg0OGjrFlyxaWLl3KzJkz8fb2ztT5M8Lc3JxKlSoZ/bjJRUdH4+vri4uLC9aprJz06K+HQADu5YpQtUqVbI1FZEB0NAk1axIbF0c5FxesX8NZKV5Hr3qfibxH2iz/kTbLf3KyzW7fvp3huqoS1p9++ilFmUajQVEUg/uZTVhdXV1TjFUNDw8nMDAwxdjW1Bw4cIAvv/ySMWPG0LNnz0ydO6M0Go3Re23TYm1tneq57j2NBMCjQrEci0Wkw8aGqJMn+efGDTwcHaVN8pm03mci75I2y3+kzfKfnGizjA4HgCxcdDVv3jz++ecf/vnnH06dOoWiKPz444/6MjVfmzdp0oRTp04RFhamL9u3bx8mJiY0bNgw3X3PnDnDRx99RK9evRg5cmSmz52f3HoQAsgMAUIIIYQoGIwyS0BShpyQkJCl4/Tp0wdbW1tGjhzJiRMn2Lp1K3PnzqVPnz4Gc7AOHjyY1q1b6+/fuXOHkSNH4uLiQpcuXbh06ZL+58GDB1mKKa+JionnUUDisAlJWIUQQghREKgaEmBvb09QUJD+ftLtTz/9lJkzZ9KiRQtVwTg4OLBmzRq++uorRo4cia2tLT179mT8+PEG9XQ6HVqtVn//77//Jjw8nPDwcPr27WtQt1u3bsyePVtVPHnRvcdhKAoUK2xN4UKWuR2OAIiKwsrDA8/4eLSXL8vSrEIIIYSRqUpYK1WqxPr16/Hy8qJw4cJ888032NjY0Lp1az788EPefvttPvvsM6ysrDJ97IoVK7J69ep066xbt87gfvfu3enevXumz5Uf3XucOL1XhdIpp/8SuURRMHnwAEsgKtk4biGEEEIYh6qEdcyYMYwYMYLevXsDifNoTZw4kXfeeYdmzZoxZcoUzp49y969e40arEjsYQWoUDpjsyYIIYQQQuR3qhLW+vXr89tvv3Hq1CkiIyOpWbMmXl6JM1G2aNGCHTt28Nlnnxk1UJFIeliFEEIIUdCoXjigTJkyvP3226luc3JyYuXKlaqDEqnT6hTuP0284Ep6WIUQQghRUBhllgCRM548iyAuXouFuSkli9rmdjhCCCGEEDkiS0uznj9/nuvXrxMeHo5OpzPYptFoXvv5UHNa0vhVl1KFMDWR5ViFEEIIUTCoSlhDQkIYPnw4ly9fRlEUg1Wukm5Lwmp8/41fleEAeYpGg87Dg9jYWMjEqh1CCCGEyBhVQwLmzp3LzZs3WbBgAQcPHkRRFFatWsX+/fvp06cPHh4eHD9+3NixFnj6GQJKyQVXeYqNDTHnznF9yxaZg1UIIYTIBqoS1mPHjtG7d2/at2+PrW3iWEoTExPKly/PtGnTcHZ2ZtasWUYNVIDvkxdDAqSHVQghhBAFiKqENSwsjEqVKgHoE9bIyEj99oYNG3LixAkjhCeShEfF8SwkGgAX6WEVQgghRAGiKmEtXrw4z549A8DCwoKiRYvyzz//6Lf7+/ujkbF8RuX7YjhAcUcbbK3NczkaYSAqCqs6dajy9tsQFZXb0QghhBCvHVUXXdWtW5dTp07xwQcfANCuXTtWrVqFqakpOp2ONWvW0LhxY6MGWtDpL7iS3tW8R1EwuXEDa2RpViGEECI7qEpYhwwZwqlTp4iLi8PCwoLRo0dz+/ZtFi5cCCQmtFOmTDFqoAXdf+NXJWEVQgghRMGiKmF1d3fH3d1df9/BwYHVq1cTFhaGiYkJdnZ2RgtQJJIprYQQQghRUGVp4YCX2dtL71920Gp1yZZkledYCCGEEAWLqoR1+/btGarXtWtXNYcXL/ELjCA+QYeVhSklHWVJViGEEEIULKoS1kmTJqW6ulVyGo1GElYjSRq/Wr6UPSayJKsQQgghChhVCesvv/yivx0eHs4777zDtGnTqFatmtECE//RX3AlMwTkTRoNunLliI+Pl6VZhRBCiGygKmH19PTU3w4ODgbAxcXFoFwYz4MX41fLl5SENU+ysSHmxg1u3LiBhyzNKoQQQhidqoUDRM66/zRpSEChXI5ECCGEECLnScKax8XEJuAflLh6kvSwCiGEEKIgUjUkICQkRH87NDRxftDIyEiDcoDChQurjUu88DAgHEUBBzsLHOwsczsckZroaCwbN6ZyTAwcOwYyLEAIIYQwKlU9rPXr18fb2xtvb2/atWsHwOjRo/VlST8i6+4/kfGreZ5Oh+mFC9hevw46XW5HI4QQr629e/fywQcf0KRJE2rWrEmXLl345ZdfUsxUBPDzzz/Tpk0bqlWrRufOnfnjjz8MtkdGRvLxxx9Tu3ZtunTpwuXLlw22x8fH07ZtWw4cOJCtjym/uHXrFu3atePp06cEBQUxYMAAjhw5kmPnV9XDOnLkSDRyNXSOeOCfmLCWKynjV4UQQhRsq1evxtnZmUmTJlGkSBFOnTrFF198wdOnTxk1apS+3u7du/niiy8YMWIE9evXZ8+ePYwaNYr169dTs2ZNAJYvX87t27f59ttv2bZtG+PGjWP//v2Ym5sDsGbNGkqVKkXr1q1z46HmOW+88Qaurq40bdoUAC8vLxo0aJBj51eVsI4ePdrYcYg06C+4kh5WIYQQBdx3332Ho6Oj/r63tzchISH8+OOPfPjhh5iYJH5xvGjRIjp06MC4ceOAxG+Gb926xdKlS1m5ciUAJ0+eZMSIETRu3BgPDw8aNmzI/fv3qVSpEoGBgaxcuZL169fn+GPMqzQaDUuXLsXPz4+EhATKlSuXo52XRr/oKiEhwdiHLNAevJiDVXpYhRBCFHTJk9UkHh4eREREEBWVeIHyw4cP8fX11Q9ZTNK+fXv+/PNP4uLiAIiLi8PKygpA/3/Stvnz59OlSxcqVaqU4diGDRtGo0aN8PT0pEmTJsyYMYOYmBj99iNHjvDOO+/g7e1NrVq16NWrF8eOHTM4xq+//oq7u3uqPy1atEhRL7kjR47g7u7OwIEDDcrv3LnDqFGjePPNN6lRowadO3fmt99+029XFIVVq1bRpk0bPD096dixI3v27DE4xuLFi/Xnd3Z2pnz58mzYsAF3d3cmTZqU4ecoK1T1sAJs3bqV69ev4+3tTatWrVi6dCnff/89CQkJNG/enFmzZmFnZ2fMWAucqJh4noUmvtjLSQ+rEEIIkcL58+cpUaKEPue4e/cuABUqVDCoV7FiReLj43n48CEVK1akWrVqbNmyhZo1a7Jx40YKFSqEi4sLly5d4sSJE+zbty9TcTRu3Jj+/ftjZ2fHgwcPWLBgAebm5kycOBGAR48e0bx5c959911MTEw4duwY77//PmvWrKFevXoGx/r+++8pVOi/jqo1a9bw999/p3lurVbLvHnzMDU1NSj39fWld+/elCpVis8//xwnJydu3brF48eP9XVmzpzJzz//zIgRI6hRowZnzpxh5cqVlCtXjsGDB6d6voiICJYsWZLifNlJVcK6YsUKvv76a0xMTNiwYQMffPABK1asoHv37sTExPDbb79RqlQpJk+ebOx4C5SHAZEAFHOwws7aPJejEUII8dqJjEx7m6kpvOh5fGVdExOwtk5ZNyoKk+joxPtJF0a9XDcLzp07x549e/RJIfw3e5G9vWFHT9L9pO0jR47k3XffpX79+pibmzNr1iysra2ZMWMG48aNM0gYM2LQoEHodDoSEhIoWrQojo6O+Pr66rcPGDBAf1un01GvXj1u377Nli1bUiSsVatWNehN3r17d7rn/uWXX3j+/DktWrTQPz5I7Bk1Nzdn48aN+oQ++bjTBw8e8NNPPzF9+nR69+4NQM2aNfHz82PFihUMHDhQP8wiuRUrVlCkSJEUfxRkJ1UJ69atW2nQoAHLli1j5cqV/N///R8jR47kww8/BMDGxoaDBw9KwppFD/0jAOldzQ+UYsVkOIwQIv9J75vQ9u0heaJUvDi8+No9haZNIfkV4y4u8OwZNoDXy3Xr1IGzZ1WFm9zTp08ZP3489erVY9CgQZne39nZmT179vDw4UOKFSuGnZ0dP//8M4qi0LNnT/7++2+mT5/Oo0ePqF27NjNnzkx1SEJyn332Gdu2bQOgUKFCfPHFFwbxfvPNN5w6dYrAwED9zAZVq1bNdOzJRUZGsnjxYkaNGsXVq1cNEtbTp0/Tpk2bNL/xPnXqFABvvfWW/jMsISEBT09Pdu3axZMnT3B2djbY58mTJ6xZs4Zvv/2WH374IUuxZ4aqMayPHz+mXbt2WFhY0L17d7RaLdWqVdNvr169Ov7+/kYLsqB6FJCUsMr41TzN1pbo+/e5fPAg2NrmdjRCCPHaCwsLY9iwYRQuXJjFixcb9AI6ODgAEB4enmKf5NsBTE1NcXFxwc7OjvDwcL799lu++OIL4uPjGT16NO3bt+fIkSNoNBpmzJjxyrhGjRrF5s2bmTp1Ko0bN6ZUqVJAYo/qBx98wPnz5xkzZgxr167ll19+oUmTJvpxs2p9//332Nra6ntIkwsJCaF48eJp7hscHIyiKNSvX5+qVatStWpV6tati4+PD5CYnL7sm2++oXr16jRv3jxLcWeWqh7W+Pj4FAOVzcz+O5SZmRlardYI4RVsfs8S/5ItW0ISViGEENkgIiLtbS+PTwwISLvuy18bv/gqPCoqips3b+Lu7o5N0qIqqXzFnBkxMTEMHz6c8PBwNm/enOKre1dXVyBxLGvS7aT75ubmlC1bNtXjLl68mEaNGlGzZk3++ecf/P396du3LzY2NvTq1StDFxeVKVOGMmXKULNmTcLCwhg7diy//vor9+/f5/r16yxdupRWrVoZPJas8Pf358cff2Tu3Ln66biSK1y4MAHptJuDgwMajYYNGzbo94+JicHX1xcXFxcqV65sUP/69ev89ttvbNmyJUtxq6H6oqu7d+9y9uxZ/V8wN2/e1Cetd+7cMU50BVzSkqylikmvnRBCiGyQmW+F1NTVaNBZWyfeN8IqgAkJCYwbN467d++yfv16SpQokaJO2bJlcXFxYd++fQbJ4Z49e/D29sbCwiLFPnfu3GHHjh0GV89DYvJma2tLdHR0pmONiYnhwYMHAMTGxgIYJJV+fn5cvHgRFxeXTB87ycKFC/Hw8OCtt95Kdbu3tzf79+9nwoQJqQ4LSFrkKSQkRD8LQFRUFCYmJnh4ePz3R8YLc+fOpX379nh6eqqOWS3VCet3333HsmXL9GMwZs+erZ+PS1EUWVggi7Q6hWchiX95lSoqCWueFh2NZdu2uEVGwu+/y9KsQgiRTaZPn84ff/zBpEmTiIiI4NKlS/ptVapU0Sejo0ePZsKECZQrV4569eqxZ88eLl++zE8//ZTqcWfOnMmwYcNwcnICEntpixcvjo+PD127dmX58uXUr18/zbguX77Mzp07qV+/Pra2tly8eJEffvhBn0i6urpSsmRJFixYgE6nIyoqikWLFqX7dX1GbN++nQ0bNqS5fdSoURw5coR+/foxdOhQnJycuHPnDtHR0QwbNowKFSrQv39/Pv30U9577z1q1KhBREQEf/31FytWrGD58uX6Yz158oTAwMBMz55gLKoS1rVr1xo7DvGS0CgtWp2CuZkJjvZWr95B5B6dDtPjxykERMnSrEIIkW1OnjwJJHaSvezQoUOUKVMGgI4dOxIdHc3KlStZsWIFFSpUYMmSJXh5pbgEjAMHDuDn52cwhZOFhQULFy5k+vTpjB49mjp16vD555+nGZe9vT03b95k586dxMTEUKJECQYNGsTIkSP1x1u8eDH/+9//GDt2LKVKleKDDz7g9OnTXL16VfXz0bp1a/3KXalxcXFh06ZNLFiwgOnTp6PVanFxceH999/X15kyZQoVKlRg8+bNLF26FBsbG4oXL07nzp0NjqXT6Rg4cGCKi7ByikZJbQFekaorV64AGFxglh2ioqL47fBF1v3xjLIl7Pi/T1tm6/lEFkVG6q+0jQoIwObFX+gib4uKiuLGjRupfu0l8iZps/xH2iz/yck2y0xeZfSVroRxBEUkTi9RqqgsviCEEEKIgk3VkICMzHem0WhYs2aNmsMLICg8MWEtWUz+IhVCCCFEwaYqYf3rr7/QaDRUrVoV6zRWq5CRBlkTrO9hlQuuhBBCCFGwqUpYJ0yYwMqVK3n69CkffPABffr0ydH1ZAsCC7PE0RqVy6e/qoYQQgghxOtO1RjWoUOHcvDgQbp06cK8efNo3749e/fuNXZsBVrnekX4dlwDKpUtnNuhiAxQbGzQWslsDkIIIUR2UH3RVaFChfjkk0/Yv38/derUYcKECfTs2ZPTp08bM74Cy8xUI8MB8gtbW6IDA7l04oQszSqEEEJkgyzPElCiRAlmzpzJzp07KVGiBO+88w5Dhw7ln3/+MUZ8QgghhBCigFM1hnXJkiWplnt4eBATE8OJEyf4888/uXbtWqaPfefOHWbMmMHFixextbWlS5cujBs3LtWl1JJTFIWVK1eyYcMGgoKC8PDwYPLkyelOqCuEEEIIIfI+oyasyWm12kwfNzQ0lMGDB+Pi4sLixYvx9/dn9uzZxMTEMHXq1HT3XblyJYsWLWLChAm4u7uzfv163n33XXbs2EHZsmUzHYsQGRYTg2X37lSKiICdO2VpViGEEMLIVCWs2fV1/6ZNm4iMjGTJkiUULlwYSEx8p0+fzvDhwylRokSq+8XGxrJ8+XLeffddhgwZAkDt2rVp27Ytq1at4ssvv8yWeIUAQKvFdP9+HIAoFX+oCSGEECJ9eWqlq2PHjuHt7a1PVgHatWuHTqfTrx+cmgsXLhAREUG7du30ZRYWFrRu3Zpjx45lZ8hCCCGEECKbqUpYPTw82LVrl7Fj4e7du7i6uhqU2dvb4+TkxN27d9PdD0ixb8WKFXn8+DExMTFGj1UIIYQQQuQMVUMCsmsVq7CwMOzt7VOUOzg4EBoamu5+FhYWWFpaGpTb29ujKAqhoaFYGWmOTEVRiIqKMsqx0hIdHW3wv8jjoqJIGrUaHR0N2fz6EMYh77P8R9os/5E2y39yss0URUGj0WSorqqEtSCLj4/nxo0bOXIuX1/fHDmPyBqT6Gi8Xtx+8OABusDAXI1HZI68z/IfabP8R9os/8mpNnvVLFBJVCes586de+VMAF27ds3UMe3t7QkPD09RHhoaioODQ7r7xcXFERsba9DLGhYWhkajSXffzDI3N6dSpUpGO15qoqOj8fX1xcXFBWtr62w9lzCCyEj9zXLlymFdrFguBiMySt5n+Y+0Wf4jbZb/5GSb3b59O8N1VSesW7ZsYfPmzWlu12g0mU5YXV1dU4xVDQ8PJzAwMMX41Jf3A7h37x6VK1fWl9+9e5fSpUsbbThAfHw8iqJw584doxwvLUlDLvz8/DLcVS5ykaLA9u2JN4OC0KQzfEXkHfI+y3+kzfIfabP8JyfbLD4+PvuHBEyePJmWLVuq3T1VTZo0YdmyZQZjWfft24eJiQkNGzZMc79atWphZ2fH3r179QlrfHw8v//+O02aNDFafDn1ZtNoNBnuIhd5gEYDL/5okl/H+Ye8z/IfabP8R9os/8nJNtNoNNmfsBYpUgRnZ2e1u6eqT58+rFu3jpEjRzJ8+HD8/f2ZO3cuffr0MZiDdfDgwTx+/JgDBw4AYGlpyfDhw1m8eDGOjo64ubmxceNGQkJCeO+994wWn5eX16srCSGEEEIIo8pTF105ODiwZs0avvrqK0aOHImtrS09e/Zk/PjxBvV0Ol2K8bPDhg1DURR++OEH/dKsq1atklWuhBBCCCHyOY2iYo6qgQMH8uGHH+Lt7Z0dMQkhhBBCCKGnKmEVQgghhBAip6gaEvD7779nqN5bb72l5vBCCCGEEELoqephrVy5MhqNxmDFq6SrvJLKNBpNjk2wL4QQQgghXl+qL7oaPnw4DRo0ABIn6B81ahQTJ06katWqRgtOCCGEEEII1QlrxYoVefPNNwEIDg4GwMPDQ18mhBBCCCGEMZio2cnKyoro6Gj9/ZiYGACWLl3K06dPjROZEEIIIYQQqExYy5Yty549e4iPjwdg69atmJiYEBoaSufOndm9e7dRgxRCCCGEEAWXqoS1b9++nD59mkaNGtG0aVOWLl1Kly5d2Lp1K927d2fChAl88sknxo5VCCGEEEIUQKrnYd2zZw+HDh0iMjISLy8vhgwZgqWlJQCnTp1i0qRJHDt2zKjBCiGEEEKIgifbFg4ICQmhcOHC2XFoIYQQQghRgMhKV0IIIYQQIk9TNa3V9u3bM1Sva9euag4vhBBCCCGEntFWukpxYFnpSgghhBBCGIHqhQMmT55My5YtjRmLEEIIIYQQKaia1gqgSJEiODs7p/sjUrpz5w7vvPMONWvWpGHDhsydO5e4uLhX7qcoCitWrKBZs2ZUr16d3r17c+nSpewPWKhqs4CAAObOnUuXLl3w8vKiSZMmfPzxx/j5+eVQ1AWb2vdZcqtXr8bd3Z3hw4dnU5Qiuay0mb+/PxMnTqR+/fpUr16ddu3asXPnzmyOWKhts+DgYKZOnUqzZs2oWbMmHTt2ZOPGjTkQccF2//59pk6dSpcuXahSpQodO3bM0H55Jf9Q3cOq0WiMGUeBEBoayuDBg3FxcWHx4sX4+/sze/ZsYmJimDp1arr7rly5kkWLFjFhwgTc3d1Zv3497777Ljt27KBs2bI59AgKHrVtdu3aNQ4cOECPHj2oUaMGwcHBfPfdd/Tq1YvffvsNR0fHHHwUBUtW3mdJAgMDWbp0KUWLFs3maAVkrc0CAgLo3bs3FSpU4KuvvsLOzo5///0303+giMzJSpuNHTuWu3fv8tFHH1GqVCmOHTvGl19+iampKW+//XYOPYKC599//+Xo0aPUqFEDnU6X7rDO5PJM/qGo4O7urrRv314ZPHiwMmzYMGXs2LHKV199pWzYsEG5e/eumkMWCMuWLVNq1qypBAcH68s2bdqkeHh4KE+fPk1zv5iYGKVWrVrKggUL9GWxsbFK8+bNlWnTpmVjxEJtm4WGhirx8fEGZU+ePFHc3d2VVatWZVe4QlHfZsl98sknyqeffqoMGDBAef/997MpUpEkK202YcIEpXfv3kpCQkI2RymSU9tmAQEBipubm7J161aD8v79+yuDBg3KrnCFoiharVZ/e+LEiUqHDh1euU9eyj9UDQmoW7cujo6OxMXFERwczI0bN9i2bRvTp0+nffv2TJgwgYSEBGPn1vnesWPH8Pb2Npiftl27duh0Ok6ePJnmfhcuXCAiIoJ27drpyywsLGjdurUszpDN1LaZvb09ZmaGX2CULFkSR0dHAgICsitcgfo2S3Lu3DkOHjzIxx9/nI1RiuTUtllERAR79+6lX79+mJqa5kCkIonaNkvKDQoVKmRQbmdnl+EeP6GOiUnmU768lH+oSljXrVvHunXr2LBhAz///DP79+/n/PnzHD16lAkTJrB3715WrFhh7Fjzvbt37+Lq6mpQZm9vj5OTE3fv3k13PyDFvhUrVuTx48fExMQYP1gBqG+z1Ny7d4/nz59TsWJFY4YoXpKVNtNqtXz11VeMGDGC4sWLZ2eYIhm1bXbt2jXi4+MxMzNjwIABVK1alYYNGzJv3jzi4+OzO+wCTW2blSpVikaNGrFs2TJu375NREQEe/bs4eTJk/Tv3z+7wxaZlJfyD9UXXaWmRIkSvPfee/To0YMdO3YY89CvhbCwMOzt7VOUOzg4EBoamu5+FhYW+qVvk9jb26MoSrr7iqxR22YvUxSFGTNmULx4cTp06GDMEMVLstJmGzZsIDo6miFDhmRTdCI1atvs2bNnAEyZMgVPT09WrVrF4MGDWbNmDYsWLcq2eEXW3meLFy+mWLFidOjQgdq1azNhwgQmT55MmzZtsitcoVJeyj9UX3SVnrFjx/LgwYPsOLQQ+dLixYs5ffo033//PTY2NrkdjkjF8+fPWbRoEXPmzMHCwiK3wxEZoNPpAGjQoAGTJk0CoH79+kRGRvLDDz8wcuRIrKyscjNE8RJFUZg8eTK+vr4sWLAAJycnTp06xaxZs3BwcJA/6EWaVPWwrlixAn9//zS3Fy1aFC8vL9VBva7s7e0JDw9PUR4aGoqDg0O6+8XFxREbG2tQHhYWhkajSXdfkTVq2yy5LVu2sHTpUqZPn463t7exQxQvUdtmCxcuxN3dnTp16hAWFkZYWBgJCQkkJCTob4vskZXfjZCYpCbn7e1NXFwc9+/fN26gQk9tmx05coR9+/axaNEiOnbsSL169Rg/fjxdu3Zl9uzZ2RmyUCEv5R+qEtZvv/2W5s2bM2jQILZu3UpERISx43otubq6phjbEx4eTmBgYIrxIS/vB4ljIJO7e/cupUuXlh6EbKS2zZIcOHCAL7/8kjFjxtCzZ8/sClMko7bN7t27x9mzZ6lbt67+58KFC5w4cYK6dety6tSp7A69wFLbZpUqVUr3uC9/yArjUdtmt2/fxtTUFDc3N4NyDw8PAgICiI6OzpZ4hTp5Kf9QlbD+8ccffPTRR4SGhvL555/TqFEjxo8fz5EjR9BqtcaO8bXRpEkTTp06RVhYmL5s3759mJiY0LBhwzT3q1WrFnZ2duzdu1dfFh8fz++//06TJk2yNeaCTm2bAZw5c4aPPvqIXr16MXLkyOwOVbygts0+++wz1q5da/BTuXJlatasydq1a6levXpOhF8gqW0zZ2dn3NzcUvwxcerUKaysrF6Z0Ar1stJmWq2WmzdvGpRfu3aNokWLYm1tnW0xi8zLU/lHVufFunnzpjJ//nylefPmiru7u1K/fn3lf//7n3Lp0qWsHvq1ExISojRs2FAZMGCAcvz4ceWXX35R6tSpo0yfPt2g3qBBg5RWrVoZlC1fvlzx9PRUVq9erZw6dUoZPXq04uXlpTx48CAnH0KBo7bNbt++rdSuXVvp2LGjcv78eeXixYv6n/v37+f0wyhQsvI+e5nMw5ozstJmhw4dUtzd3ZUZM2YoJ06cUL777julatWqytdff52TD6HAUdtm4eHhSrNmzZTWrVsr27dvV06dOqXMnTtXqVy5srJ06dKcfhgFSlRUlLJ3715l7969yoABA5SmTZvq7z9//lxRlLydf2gUxXgTn507d441a9Zw8OBBAMqVK0eXLl3o3bu3rBjzwp07d/jqq6+4ePEitra2dOnShfHjxxtc5DFw4ED8/Pw4fPiwvkx5sTTahg0bCAoKwsPDg8mTJ8tY4Rygps1+/fVXJk+enOrxunXrJmO1spna99nLBg4ciI2NDcuXL8+JsAu0rLTZnj17+L//+z98fX0pXrw4vXv35v3335cVGbOZ2ja7f/8+33zzDefPnyc8PJwyZcrQq1cvBgwYIPPpZqNHjx7RsmXLVLetXbuWevXq5en8wygJa2xsLAcPHmTXrl2cOHECgIYNG2Jubs6RI0cwNzdn7ty5tG7dOssBCyGEEEKIgkV1wqooCidPnmTXrl0cPHiQyMhIqlSpQufOnenUqZO+RzUgIICPP/6Yx48fc+jQIaMGL4QQQgghXn+q5mGdNWsWe/bs4fnz5zg5OdGnTx+6du3KG2+8kaJu8eLF6dmzJxMnTsxysEIIIYQQouBR1cPq5eVFq1at6Nq1Kw0aNHjlOKFHjx5x9uxZunXrpjpQIYQQQghRMKlKWKOiomS1HiGEEEIIkSOMOkuAEEIIIYQQxqZqDOuIESNeWUej0fDdd9+pObwQQgghhBB6qhLWI0eOYGVlRdGiRUmrg1bmvxNCCCGEEMagKmFt2LAhp0+fpkSJEnTv3p127dpha2tr7NiEKBDi4uIIDQ1Fp9NRokSJHD13bGwsISEhmJmZyeIeQggh8izVY1j9/f359ddf2bZtG4GBgbRp04YePXpQt25dY8coxGvnypUrrF69mhMnThASEgJAzZo12bx5c7af+9SpU6xdu5Zz584RHh4OQIcOHfj666+z/dxCCJGX/fHHH5QsWRIPDw8ADh48SPny5VOdtlPkLKNcdPXXX3+xbds29u/fT7Fixdi+fbvMIiAybd++fYwdOzbVbW+88Qa//fZbDkeUPQ4ePMj48eNxdXWlb9++lCtXDgBHR0cqV66credev349M2bMoHbt2vTo0UPfo1u6dGlcXFyy9dxCCJHXLV++nOPHjzNjxgxCQkIYOXIkS5cupWbNmrkdWoGnakjAy1xdXXF1daVYsWL4+/uj0+mMcVhRQI0YMQJXV1f9/WXLluViNMYVEhLClClTaNSoEQsXLjRYczu7+fr6Mnv2bN5++22+/PJLGWcuhBAv6dWrF1u3bqVNmzYAvPXWW5Ks5hGqE1atVsvhw4fZunUrx48fp3LlygwePJhOnTphZ2dnzBhFAdOgQQPq1aunv//LL78QHBycixEZz6+//kpsbCyzZ8/O0WQVYN26dTg5OTFlyhRJVoUQIhWOjo789ttv3Lp1C2traypWrJjbIYkXTNTs5OPjQ+PGjZk2bRrly5dn69atbN26lf79+2Nvb2/sGEUBER8fD4CJScZelg8fPmTMmDG8+eab1KhRg7fffpsjR46kWnfSpEm4u7un+Fm8eLFBvX379tG9e3e8vLwM6q1atcoo8Vy6dAkPDw+WLVtG06ZN8fT05K233mLFihUpvplwd3fnf//7Hzt37qRNmzZUq1aN7t27c/bsWYN6fn5+fPnll7Rp04bq1atTr149xowZw6NHj1Kcu2rVqkyfPp0GDRrg6elJx44d2bJlS4rHEhUVxezZs/UxtmnThlWrVhnMCpLa85n8Z+DAgUDiRWULFy6ke/fu1K5dm5o1a9KvXz9Onz5tcM5Hjx6l+Vx37NhRfzyAM2fO4O7uzr59+1LU9fLyYtKkSfr7v/76K+7u7ly5ciVF3SQDBw40OP7EiROpVq0ad+7cMaj33nvvUbduXfz9/dM8VtLjcHd35+DBgwbbYmNjqVu3bqqP8/r16wwdOpRatWrh5eXF4MGDuXTpkkGd1B5LUFBQqq/lvn370r17d4OyuLg4Fi1aROvWrfH09KRp06bMnTuXuLg4g3pJr72XDR8+nBYtWqR4rJlpszNnzhjUe//991PE/3J7JD/Xr7/+alB+584d/fsu6T1y6NChFPGEhYUxa9YsWrRogaenJ02aNOHTTz8lKCgozfj8/f1p0aIF3bt3JzIyMlOPIyYmhrZt29K2bVtiYmL09UJCQmjUqBF9+vRBq9WmiBP+a+f0fpKeh0mTJuHl5cXDhw957733qFmzJo0aNWLJkiUpZvFZtWoVffr0oV69elSvXp3u3bun+h7KaPvfvXuXQYMG0bBhQ/3raerUqfpx+ZD593/y9o2IiKB79+60aNGCgIAAg3oZec1B6q+ly5cv65/Hlx/34sWLsbCwwNPTk4oVK/L9998b/D4TuUdVD+uaNWuwsrKidu3a3L9/n2+//TZFHZmHVWRWUsKakZ7HZ8+e0adPH6Kjoxk4cCBFihRh27ZtfPDBB/oP5JcVKVKEyZMn6+9/+umnBtsvXrzIuHHjqFy5MhMmTMDOzo7g4GB8fHyMFk9ISAjnz5/n/Pnz9OjRg6pVq3L69GkWLFjAo0ePUnxInD17lj179jBw4EAsLCzYuHEjQ4cO5eeff8bNzQ1IvIDr4sWLdOjQgZIlS+Ln58fGjRsZNGgQu3fvxtraWn/uq1evYmZmRr9+/ShXrhwHDx7kiy++ICQkhPfffx8ARVH44IMPOHPmDD179sTDw4Pjx48zd+5c/P39+eyzzwCYO3euPs7z58+zefNmJk+eTJEiRQAoVqwYkPih8/PPP9OxY0d69epFZGQkv/zyi/5xJF3ckJd8/vnnnD59mokTJ7J582ZMTU3ZtGkTJ06cYO7cuRmazcHS0pKtW7fSqlUrfdnvv/9ObGxsirr//vsv/fv3x9bWlqFDh2JmZsbmzZsZOHAgP/30EzVq1MjyY9LpdHzwwQecP3+et99+m4oVK3Lr1i3WrFmDr68v//d//5flc2TW2bNnOXr0qOr9//33X/r27UuJEiUYNmwYNjY27N27l5EjR7J48WL9+y4yMpL+/ftz584devToQZUqVQgODubw4cP4+/vj6OiY4tjh4eEMGzYMMzMzVq5cme5MOKk9DisrK+bMmUPfvn355ptv9L97/ve//xEeHo6Pjw+mpqapHq9u3boG76+kYVHJ50CvVauW/rZWq2Xo0KHUqFGDTz75hOPHj7N48WK0Wq3BdQFr166lRYsWdOrUifj4eHbv3s3YsWNZvnw5zZo1S/PxpSU6OpqSJUvSokULbG1t+ffff9mwYQMBAQH6mNW+/+Pj4xkzZgyPHz9m48aNFC9ePNPxpWX+/PkZqhcWFsaKFSuMdl6RNaoS1tKlSwNw7969NOvIV44is5KuWLe0tHxl3RUrVvDs2TPWr19PnTp1gMSxR507d8bHx4eWLVsa9NQmJCRga2tLly5d9GUvJ6x//PEHiqKwcuVKnJycgMS/5jOSsGY0nqQej9GjRzNq1CgA+vfvz+TJk9m8eTMDBgzQJ6IAt27dYuvWrXh6egKJV/O3bduWRYsWsWTJEgCaNWtG27ZtDeJp3rw5vXv3Zv/+/XTt2hVAf+4ZM2bQrVs3APr168d7773H4sWL6dWrF0WKFOHQoUOcPn2acePG8cEHH+hjHDNmDGvXrmXAgAGUK1fO4LnUarVs3ryZVq1aUaZMGYNYHBwcOHz4sMEfIm+//Tbt2rVj3bp1zJo165XPb06zt7dn5syZvPfee6xYsYKOHTsyZ84cWrVqZfC409O6dWv27dvHs2fP9Mn71q1bad26dYoLCL/99lvi4+PZuHEjZcuWBaBr1660bduWefPm8dNPP2X5Me3atYtTp06xbt06/WsUEi9onDZtGhcuXDBIgnLCvHnzaNKkCceOHTMo12g0GboWYubMmZQqVYqtW7fqX1/9+vWjb9++zJ8/X5+wrlq1ilu3brFkyRKDP2Y//PDDVOcSj4uL48MPP+TZs2ds2rTplVO+pfU4atSowdChQ1m5ciWtW7fm2bNn7N69m88++4wKFSqkebyyZcvqXweQOCwKSPO1FxsbS+PGjZkyZYr+ORgxYgQrV65k4MCB+oR8//79WFlZ6ffr378/3bt358cff1SVsFatWtUgsYbERHP79u36+2re/4qiMHnyZC5cuMDatWvTfa4y6+jRo5w5c4bGjRtz/PjxdOsuX74cMzMzqlatarTzC/VUDQk4fPjwK39S+0pGiPQkfY2UWm/Hy44ePUr16tUNPnhtbW3p3bs3fn5+3L5926B+fHz8K3tuIyMjMTExUTWsJTPxmJqaMmTIEIP933nnHYAUQwi8vLz0ySok/rHYsmVLTpw4of86MfkHUHx8PMHBwZQrVw57e3uuX79ucLxixYoZfOiZmpoyePBg4uLi+PPPPwE4duwYpqamKb4Ce/fdd1EUJcWH8quYmprqn3udTkdISAgJCQl4enqmiA8Se22CgoIMftL66jQyMjJF3bREREQQFBREREREhuJu1KgRvXv3ZunSpYwePRpLS8tUvyZNS5UqVahUqRI7duwAEodunDlzJsXX9FqtlpMnT9KqVSuDJKV48eJ07NiR8+fPZzjm9Ozbt4+K/9/evQc1cb19AP8maWSsWC+oqEQsNWiwlgFvLaJAvRUFpIKXFgVmBBwt0MqggKMSFRU7KRq5VFEUiiCCF8QgGjDWlijidCpoEdSqoIBSI6hQhKjJ+weTfVmSQBLQ9lfO5y/YbDZnd7PJyXOe8+yYMfjoo49ox+uzzz4DALUh7tbWVrVj+/r1a43b1uecqeTn5+PGjRsIDQ1Ve8zExASPHz/u9PnPnj3DlStXMG/ePOrc1tfXo6GhAdOnT0dlZSWVupGfnw8ej6dx5KVjcEWhUCAsLAylpaXYv38/VcXDkP0AgKCgIHC5XISHh2PLli2YOnUqfHx8Ot2mIZYtW0b9zWAwsGzZMrx69Yq6rgH6Z8Xz58/R2NiISZMmabwO9Tn/jY2NkMlkKCoqwi+//EIrb6nv9Q+0jd6IRCIIhUJYW1vrdyA6oVQqsWvXLnzxxRddjlrU1dUhLS0N33zzDakz/y9hUIRVLpe/8wkjxH9fbW0t3nvvPZ06rLW1tRo/cFTVBWpra2mRysbGxi5LrdnY2CAtLQ3bt2+Hv78/jI2N8eLFC53brmt7hg0bpjYx0cLCAkwmEzU1NbTlo0ePVtvmhx9+SHUQhg4dipaWFiQmJuLkyZOoq6ujRYxUUev2z+2YI6yaVKDKea2pqdHYRtV6Hduoi+zsbBw6dAj379+nUj8AqEVjASAuLk4tHxP4/xSD9lTpCbpo/yPhgw8+gIuLC8LCwjp9X4SHh+PChQsoLy9HTEyM3jdX8PDwQFZWFvz8/JCdnQ1bW1u1c1pfX4+XL19qjCKNGTMGCoUCjx496nYdyKqqKty9exd2dnYaH3/69Cnt/+PHj1ORvfbMzMzUlulzzoC2TvquXbvg5uamsZSbra0t8vLykJKSAhcXF7BYLLVr8cGDB1AqldizZw/27NmjdZ9MTU3x4MEDzJ07V+M6HQmFQpSUlIDBYNByTw3ZD6AtxWnHjh1YtGgRjIyMsGPHjh4fgWQymbQfOwCo91P76/Xnn3/G3r17UV5eTstb1tQefc6/n58fSktLAQAzZszA7t27aY/rc/1nZmZSudvPnz9Xe7w7Tp8+jT///BNCobDLMomxsbEYNmwYNVJF/PMMvtOVs7Mz3N3daRElguiO+/fvg8Ph4L33eqTaGs2TJ080ftC25+Ligps3b+Lw4cNvrYB/+whHT4mKisLJkyfh6+sLGxsb9O/fHwwGAyEhIbTO69t4bV3k5OQgIiICs2fPhp+fH0xMTMBisZCYmIiHDx+qrb906VK1FAfVUGdHgYGBap9B7fP82ouMjISFhQXkcjmKi4tx6NAhAMDmzZu1tr28vJzqyN2+fVvretosWLAAAoEAJSUlVE7zP0WhUGDs2LG0PO72hg8fTvt/1qxZWL58OW2ZUCiETCZTe64+5wxo6wzV1NRoncy4dOlSSKVSREdHa03JUaUMrFixAjNmzNC4TlfRUU1KS0uxc+dOpKWlYdOmTcjJydEaoOlqP1SkUimAtqhlVVWVWufyXfjtt9+wevVqTJkyBXw+H0OHDgWbzcaJEyc0dt70Of8bN25EQ0MD7t69i8TERPD5fCpPVN/rv6SkBCEhIbhx4wY1wVuXIEZXVJO/PD09u0wxuHv3LrKzsyEQCMBms7v92kTPMKhn4OzsjPz8fBw/fhwjRoyAm5sbFixYQMo/EAaTy+UoLy+nTVDpzMiRIzXmUN+7d496XOXVq1d48OCB1i81FSaTifDwcNy+fRvV1dXg8/mQyWRYt25dj7WHw+Hg0qVLaGpqokUwKysroVAo1DrVVVVVatusrKxE3759aXlpX375JW1mfGtrq1p0lcPh4ObNm1AoFLQoq6qNqmiHmZkZioqK1NqoWq+rjn9HYrEYo0aNQnx8PC2SExsbq3H90aNHY9q0abRl2qKgY8eOVVtX20QWa2trfPLJJwDa8n5v3brVaQ5bc3Mz1q9fDy6XC1tbWyQlJWH27Nl6DVEOGjQIM2fORGRkJOrr6zFv3jy1Em2DBw9G3759tb5/mEwmRowYofNramNubo6KigrY2dnpFOEbPny42rH96aefNHZY9DlnLS0tiI+Ph5eXl9b3kpGREfbv34/79+/j8ePHUCqVateiqtPHZrPVXrsjc3Nz3Llzp9N1VIKDg7Fw4UJYWVnB09MTP/74I9asWWPQfgBARUUFEhIS4OHhgYqKCmzcuBEikQj9+/fXqT26UCgUePjwIa0jpno/qdomFothZGSEgwcP0jrgJ06c0LhNfc6/6ppwdHTE4MGDER4ejtWrV2PMmDF6X/+enp5YtWoV6urq4OLigujoaAgEAl0OQ6eOHDmC+vp6BAcHd7luTEwMeDwe5s+f3+3XJXqOQTmsUVFRkEqliI2NxYQJE5CcnAxXV1d4eHhofUMTRGdEIhHkcrnW4cqOHB0dcf36dVy7do1a1tzcjKysLJiZmYHL5VLLJRIJWlpaqFy9zhw+fBhXrlyBQCDAtGnTdJ6Eomt7HB0d8ebNG6Snp9Oen5ycDABqEx+uXbuGsrIy6v9Hjx5BIpHA3t6e6php6qAdPnxYLYfQ0dERT548QV5eHrVMoVAgNTUVffr0oY69g4ODxjampKSAwWDAwcFBp2Oiompf+2hvaWmpWsmmd02hUGjt3AJtM4kfPXqEnTt3IiIiAmZmZoiIiFArAdUVT09P3Lp1C87Ozhpz4VgsFuzt7SGRSGilyGQyGXJzczFp0qQeqW09b9481NXVaSxj1tLSgubm5m6/hi5SU1Px8uVLrZHw9iwsLGBnZ6fxWjQxMcHUqVORmZlJlTxqr30+89y5c1FRUYGCggK19TpOulJF7Hk8HlasWIGkpCSN0XVd9uPVq1dYv349hg0bhg0bNiA6OhoymeytTDRsf70qlUqkp6eDzWZT1zWLxQKDwaB9LlRXV/f4fBPVXATVdaLv9a86/qampli7di1Onz5NRagN9ffff2Pfvn3w9fWlJtRqU1JSAolEgrVr15LJ4/8yBo+9stlszJkzB3PmzEFTUxPOnj2L3NxcfP/99xAIBLCzs8OCBQswZ86cf2wokvj3a25uRlpaGhISEsBisaBUKqlJKioymQzNzc3IycmBvb09hgwZgpUrV+LMmTMICAiAt7c3BgwYgFOnTqG6uhpxcXFgMpl4+fIlYmNjkZGRAVtbW0yfPr3Ttty5cwcCgQBBQUF6J/rr0h6grdM4bdo07N69G9XV1eDxeCguLoZYLMZXX31Fy7sF2iKIfn5+tLJWAGhRAicnJ+Tk5MDY2BhcLhclJSW4fPkyBg4cSNvWokWLkJGRgYiICPzxxx/gcDg4f/48ioqKEBoaSpWjmjlzJj799FPs3r0bNTU1GDduHC5dugSJRAJfX1+9h1mdnJyQn5+PwMBAODk5obq6GkePHgWXy31nnSSg7YuooaEBcrkcV69eRVFREVasWKFx3aKiIhw5cgRBQUHUDOHo6Gh4e3tDKBSqVZjojIODA4qKijqduLFmzRpcvnwZXl5e8PLyAovFQmZmJuRyucYIv2pfAFATsqqqqmgT4hobG2mRNHd3d5w9exZ8Ph/FxcWYOHEi3rx5g3v37uHcuXNISkqiItBvk1QqRUhICPV+6w4+nw8vLy+4ublhyZIlGDVqFGQyGUpKSvD48WOcPn0aQFuOpVgsxnfffUeVk3v+/DkuXLiALVu2aM0/DQoKQn5+PjZt2oSMjAzayIQu+6HKF01JSYGxsTF4PB4CAwMhFArh7OwMR0fHbh8DoC0iXVhYiPDwcFhbW6OwsBAXL17EqlWrqJEYR0dHJCcnw9/fH66urnj69CmOHDkCc3Nz3Lp1y6DXjY+Px19//QVLS0v06dMHZWVltBqyQPeu/6VLlyI3Nxd8Ph+5ublUiT6gLYLccQJoc3MzGAwGfv31V9oP67KyMgwaNAgBAQFd7pNUKoW9vX2XUXvi3euRZEFjY2MsXrwYPB4PBw4cQH5+PgoLC1FYWIh+/fphyZIlCA4O7nLSC9H71NfXIyYmhvo/MjJS67phYWFITU3FkCFDMGTIEBw9epQq+dPa2opx48Zh3759VJTyxYsXOHv2LJYsWYJvv/220xsSyOVyhIaGYsKECVQ9Un3o0h6gbXJDQkIC9uzZg7y8PGRnZ2PkyJEIDQ2Fv7+/2nanTJkCGxsbJCQkoLa2FlwuF9HR0bQv2A0bNoDJZEIkEqG1tRUTJ06kvpjaMzIyQmpqKn744QecOnUKTU1NsLCwwLZt27B48WJqPSaTib179yI2NhZ5eXk4efIkzMzMEBYWprWD1xkPDw/IZDJkZmZCKpWCy+VCIBDg3LlzuHr1qt7bM9S2bdsAtP3YHjlyJAIDAzVGx5qamrBhwwaMHz+e9vjkyZPh4+OD5ORkvW7XyGAwuszBs7S0RHp6OmJiYpCYmAilUglra2sIBAKNk/lU+9KeSCSCSCSiLWtfjofJZCIhIQEpKSnIyclBQUEB+vbtCw6HA29v7x4tHdSZoUOHwtfXt0e2xeVyceLECcTHxyM7OxvPnj3D4MGDMX78eAQGBlLr9evXD+np6YiLi0NBQQGys7NhYmICOzu7TmvqGhkZISoqCj4+PkhLS6PN7u9qP8rKypCYmIjly5fTRndWrlwJiUSCjRs34syZMz1ysx0Wi4WkpCRs3rwZAoEA/fr1Q1BQEO0Y2NnZYfv27Thw4AB27NgBDoeDtWvXoqamxuAOq6WlJS5evIgzZ87g9evXMDU1hbe3NwICAqjP2+5c/wwGA1FRUXB3d4dQKKTlXx87dgzHjh3T+LyAgAC1fVq1apVOIxUMBkNrxQfin8VQaipCp4eHDx9SH5SVlZUYOHAgXFxc4O7uDjabjaysLGRlZeHzzz/XOIuU6N2qq6sxa9YspKam0m7Hauh6/yXjxo3DsmXLOu3EEwTRu0VEREAsFtPSkXqz4uJi+Pj4GNwJJ/69DIqwNjQ0IC8vDyKRCKWlpWCz2XBycsK6devg4OBAm+UdGRmJ4cOH/yN3USEIgiAIgiD+9xnUYZ0xYwZev34NGxsb8Pl8zJ8/v9NhDUtLyx4pS0H897z//vtwc3PTWq9R3/UIgiCI3mvAgAFdzlcg/jcZlBIQFxcHd3d3g2rcEQShG5ISQBBEV0hKANFb6NxhVSqVepV4qKmp0bteI0EQBEEQBEF0pHMd1uDgYJ3qDyoUChw4cACurq7dahhBEARBEARBAHp0WM+fPw8/Pz+q5p8m169fx8KFCxETE0NqmBEEQRAEQRA9QucO69atW/H7779j+fLl1L21VZqamrB161Z8/fXXePbsGeLj45GQkNDjjSUIgiAIgiB6H70mXRUUFCA0NBSmpqY4ePAgzM3NIRaLsX37dshkMnh5eSEkJKTTO7oQBEEQBEEQhD70rhJQXFyMwMBAGBkZwcrKClKpFFZWVti6des7ua0fQRAEQRAE0bsYVNaqvLwc/v7+qK+vh6urK3bu3AkWi/U22kcQBEEQBEH0cjrnsLZnZWWFjIwMcDgciMViSCSSnm4XQRAEQRAEQQDQI8JaVlamtkwmkyEiIgIvXrxAWFgYJk+eTHv8448/7plWEgRBEARBEL2Wzh1WHo+n8cYB7Z+uelx1k4Hy8vIeaiZBEARBEATRW/0fq+0qHp75+34AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 700x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "fraud_df = df.loc[df['Class'] == 1, ['Amount']].copy()\n",
+    "fraud_df = fraud_df.sort_values('Amount', ascending=False)\n",
+    "fraud_df['cum_amount'] = fraud_df['Amount'].cumsum()\n",
+    "fraud_df['fraction_records'] = (np.arange(len(fraud_df)) + 1) / len(fraud_df)\n",
+    "fraud_df['cum_amount_share'] = fraud_df['cum_amount'] / fraud_amount_total\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4))\n",
+    "sns.lineplot(data=fraud_df, x='fraction_records', y='cum_amount_share', ax=ax)\n",
+    "ax.set_title('Ценность vs объём обработанных данных')\n",
+    "ax.set_xlabel('Доля обработанных мошеннических транзакций')\n",
+    "ax.set_ylabel('Кумулятивная доля предотвращённого ущерба')\n",
+    "ax.axvline(0.2, color='red', linestyle='--', label='20% записей')\n",
+    "ax.axhline(fraud_df.loc[fraud_df['fraction_records'] <= 0.2, 'cum_amount_share'].max(), color='gray', linestyle=':')\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a39bfe69",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:23.139498Z",
+     "iopub.status.busy": "2025-09-18T11:03:23.139063Z",
+     "iopub.status.idle": "2025-09-18T11:03:23.168140Z",
+     "shell.execute_reply": "2025-09-18T11:03:23.166778Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>abc_category</th>\n",
+       "      <th>transactions</th>\n",
+       "      <th>value_share</th>\n",
+       "      <th>transactions_share</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A (top value)</td>\n",
+       "      <td>91</td>\n",
+       "      <td>0.799971</td>\n",
+       "      <td>0.184959</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B</td>\n",
+       "      <td>80</td>\n",
+       "      <td>0.149329</td>\n",
+       "      <td>0.162602</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C</td>\n",
+       "      <td>321</td>\n",
+       "      <td>0.050701</td>\n",
+       "      <td>0.652439</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    abc_category  transactions  value_share  transactions_share\n",
+       "0  A (top value)            91     0.799971            0.184959\n",
+       "1              B            80     0.149329            0.162602\n",
+       "2              C           321     0.050701            0.652439"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "def categorize_abc(value):\n",
+    "    if value <= 0.8:\n",
+    "        return 'A'\n",
+    "    elif value <= 0.95:\n",
+    "        return 'B'\n",
+    "    return 'C'\n",
+    "\n",
+    "fraud_df['abc_category'] = fraud_df['cum_amount_share'].apply(categorize_abc)\n",
+    "abc_summary = fraud_df.groupby('abc_category').agg(\n",
+    "    transactions=('Amount', 'count'),\n",
+    "    value_share=('Amount', lambda x: x.sum() / fraud_amount_total),\n",
+    ")\n",
+    "abc_summary['transactions_share'] = abc_summary['transactions'] / abc_summary['transactions'].sum()\n",
+    "abc_summary = abc_summary.rename(index={'A': 'A (top value)', 'B': 'B', 'C': 'C'}).reset_index()\n",
+    "abc_summary\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "213f680d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**Мониторинг ценности.**\n",
+    "- Отслеживать precision/recall, FPR, долю предотвращённых сумм и факт возвратов каждые 15 минут.\n",
+    "- Пересчитывать ROI ежеквартально, учитывая реальный курс валют и обновлённые тарифы инфраструктуры.\n",
+    "- Через год при росте конкуренции и эволюции мошеннических схем ожидается повышение ценности данных: накопленные исторические последовательности позволят улучшить модели sequence modeling (LSTM/Transformers) и повысить recall на 3-5 п.п., что увеличит экономию.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed20d044",
+   "metadata": {},
+   "source": [
+    "## 6. Технологический стек и рекомендации"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "b05e59ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:23.171854Z",
+     "iopub.status.busy": "2025-09-18T11:03:23.171523Z",
+     "iopub.status.idle": "2025-09-18T11:03:23.187415Z",
+     "shell.execute_reply": "2025-09-18T11:03:23.185409Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Слой</th>\n",
+       "      <th>Рекомендуемая технология</th>\n",
+       "      <th>Альтернативы</th>\n",
+       "      <th>Обоснование</th>\n",
+       "      <th>Риски</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Хранилище сырых данных</td>\n",
+       "      <td>Yandex Object Storage + Delta Lake</td>\n",
+       "      <td>HDFS, S3, Iceberg</td>\n",
+       "      <td>Дешёвое хранение, версионирование, поддержка A...</td>\n",
+       "      <td>Стоимость запросов при горячем доступе, необхо...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Стриминг</td>\n",
+       "      <td>Apache Kafka + Kafka Connect</td>\n",
+       "      <td>Pulsar, RabbitMQ</td>\n",
+       "      <td>Гарантии доставки, re-play, поддержка late-arr...</td>\n",
+       "      <td>Требует DevOps-поддержки и мониторинга лагов</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Обработка</td>\n",
+       "      <td>Apache Flink (или Spark Structured Streaming)</td>\n",
+       "      <td>Kafka Streams, Storm</td>\n",
+       "      <td>Низкая задержка &lt;50 мс, stateful стриминг, win...</td>\n",
+       "      <td>Сложность отладки stateful-джобов, необходимос...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ML/Feature Store</td>\n",
+       "      <td>Feast + MLflow</td>\n",
+       "      <td>Hopsworks, Tecton</td>\n",
+       "      <td>Повторное использование фич онлайн/оффлайн, ве...</td>\n",
+       "      <td>Интеграция с онлайн-хранилищем (Redis/ClickHouse)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Оркестрация и качество</td>\n",
+       "      <td>Apache Airflow + Great Expectations</td>\n",
+       "      <td>Prefect, Dagster</td>\n",
+       "      <td>Планирование DAG, запуск data-quality чеков, S...</td>\n",
+       "      <td>Нагрузка на scheduler, необходимость резервиро...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Слой                       Рекомендуемая технология  \\\n",
+       "0  Хранилище сырых данных             Yandex Object Storage + Delta Lake   \n",
+       "1                Стриминг                   Apache Kafka + Kafka Connect   \n",
+       "2               Обработка  Apache Flink (или Spark Structured Streaming)   \n",
+       "3        ML/Feature Store                                 Feast + MLflow   \n",
+       "4  Оркестрация и качество            Apache Airflow + Great Expectations   \n",
+       "\n",
+       "           Альтернативы                                        Обоснование  \\\n",
+       "0     HDFS, S3, Iceberg  Дешёвое хранение, версионирование, поддержка A...   \n",
+       "1      Pulsar, RabbitMQ  Гарантии доставки, re-play, поддержка late-arr...   \n",
+       "2  Kafka Streams, Storm  Низкая задержка <50 мс, stateful стриминг, win...   \n",
+       "3     Hopsworks, Tecton  Повторное использование фич онлайн/оффлайн, ве...   \n",
+       "4      Prefect, Dagster  Планирование DAG, запуск data-quality чеков, S...   \n",
+       "\n",
+       "                                               Риски  \n",
+       "0  Стоимость запросов при горячем доступе, необхо...  \n",
+       "1       Требует DevOps-поддержки и мониторинга лагов  \n",
+       "2  Сложность отладки stateful-джобов, необходимос...  \n",
+       "3  Интеграция с онлайн-хранилищем (Redis/ClickHouse)  \n",
+       "4  Нагрузка на scheduler, необходимость резервиро...  "
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "technology_table = pd.DataFrame([\n",
+    "    {\n",
+    "        'Слой': 'Хранилище сырых данных',\n",
+    "        'Рекомендуемая технология': 'Yandex Object Storage + Delta Lake',\n",
+    "        'Альтернативы': 'HDFS, S3, Iceberg',\n",
+    "        'Обоснование': 'Дешёвое хранение, версионирование, поддержка ACID для апдейтов поздних событий',\n",
+    "        'Риски': 'Стоимость запросов при горячем доступе, необходимость настроить версионирование',\n",
+    "    },\n",
+    "    {\n",
+    "        'Слой': 'Стриминг',\n",
+    "        'Рекомендуемая технология': 'Apache Kafka + Kafka Connect',\n",
+    "        'Альтернативы': 'Pulsar, RabbitMQ',\n",
+    "        'Обоснование': 'Гарантии доставки, re-play, поддержка late-arriving событий',\n",
+    "        'Риски': 'Требует DevOps-поддержки и мониторинга лагов',\n",
+    "    },\n",
+    "    {\n",
+    "        'Слой': 'Обработка',\n",
+    "        'Рекомендуемая технология': 'Apache Flink (или Spark Structured Streaming)',\n",
+    "        'Альтернативы': 'Kafka Streams, Storm',\n",
+    "        'Обоснование': 'Низкая задержка <50 мс, stateful стриминг, windows',\n",
+    "        'Риски': 'Сложность отладки stateful-джобов, необходимость чекпойнтов',\n",
+    "    },\n",
+    "    {\n",
+    "        'Слой': 'ML/Feature Store',\n",
+    "        'Рекомендуемая технология': 'Feast + MLflow',\n",
+    "        'Альтернативы': 'Hopsworks, Tecton',\n",
+    "        'Обоснование': 'Повторное использование фич онлайн/оффлайн, версионирование моделей',\n",
+    "        'Риски': 'Интеграция с онлайн-хранилищем (Redis/ClickHouse)',\n",
+    "    },\n",
+    "    {\n",
+    "        'Слой': 'Оркестрация и качество',\n",
+    "        'Рекомендуемая технология': 'Apache Airflow + Great Expectations',\n",
+    "        'Альтернативы': 'Prefect, Dagster',\n",
+    "        'Обоснование': 'Планирование DAG, запуск data-quality чеков, SLA мониторинг',\n",
+    "        'Риски': 'Нагрузка на scheduler, необходимость резервирования metadata DB',\n",
+    "    },\n",
+    "])\n",
+    "\n",
+    "technology_table\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aae27e86",
+   "metadata": {},
+   "source": [
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    subgraph Ingestion\n",
+    "        A[Сырые транзакции] -->|REST/API| B[Kafka]\n",
+    "        B --> C[Kafka Connect]\n",
+    "    end\n",
+    "    subgraph Processing\n",
+    "        C --> D[Apache Flink Streaming]\n",
+    "        D -->|Features| E[Feature Store (Feast)]\n",
+    "        D -->|Alerts| F[Fraud API]\n",
+    "    end\n",
+    "    subgraph Storage\n",
+    "        D --> G[Delta Lake / Object Storage]\n",
+    "        E --> H[MLflow Model Registry]\n",
+    "        H --> F\n",
+    "    end\n",
+    "    subgraph Monitoring\n",
+    "        D --> I[Prometheus/Grafana]\n",
+    "        G --> J[Airflow + Great Expectations]\n",
+    "    end\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e30ec129",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-18T11:03:23.190848Z",
+     "iopub.status.busy": "2025-09-18T11:03:23.190600Z",
+     "iopub.status.idle": "2025-09-18T11:03:23.209069Z",
+     "shell.execute_reply": "2025-09-18T11:03:23.206360Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Этап</th>\n",
+       "      <th>Содержание</th>\n",
+       "      <th>Метрики успеха</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1. Подготовка (0-1 месяц)</td>\n",
+       "      <td>Настройка Kafka, Object Storage, загрузка исто...</td>\n",
+       "      <td>Время загрузки &lt; 10 мин, покрытие 100% данных</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2. Стриминг-пайплайн (1-3 месяц)</td>\n",
+       "      <td>Разработка Flink job, реализация late data han...</td>\n",
+       "      <td>Задержка &lt; 50 мс на 95-й перцентиль, падение &lt;...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3. ML и витрины (3-4 месяц)</td>\n",
+       "      <td>Фиче-стор, обучение модели, онлайн-инференс API</td>\n",
+       "      <td>ROC AUC &gt; 0.98, время инференса &lt; 40 мс</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4. Data Quality &amp; мониторинг (4-5 месяц)</td>\n",
+       "      <td>Airflow DAG, Great Expectations, алерты</td>\n",
+       "      <td>Покрытие проверками &gt; 90%, MTTR &lt; 15 мин</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5. Эксплуатация и оптимизация (5-6 месяц)</td>\n",
+       "      <td>A/B тестирование, тюнинг параметров, отчёт по ROI</td>\n",
+       "      <td>Снижение мошенничества ≥30%, ROI &gt; 5%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                        Этап  \\\n",
+       "0                  1. Подготовка (0-1 месяц)   \n",
+       "1           2. Стриминг-пайплайн (1-3 месяц)   \n",
+       "2                3. ML и витрины (3-4 месяц)   \n",
+       "3   4. Data Quality & мониторинг (4-5 месяц)   \n",
+       "4  5. Эксплуатация и оптимизация (5-6 месяц)   \n",
+       "\n",
+       "                                          Содержание  \\\n",
+       "0  Настройка Kafka, Object Storage, загрузка исто...   \n",
+       "1  Разработка Flink job, реализация late data han...   \n",
+       "2    Фиче-стор, обучение модели, онлайн-инференс API   \n",
+       "3            Airflow DAG, Great Expectations, алерты   \n",
+       "4  A/B тестирование, тюнинг параметров, отчёт по ROI   \n",
+       "\n",
+       "                                      Метрики успеха  \n",
+       "0      Время загрузки < 10 мин, покрытие 100% данных  \n",
+       "1  Задержка < 50 мс на 95-й перцентиль, падение <...  \n",
+       "2            ROC AUC > 0.98, время инференса < 40 мс  \n",
+       "3           Покрытие проверками > 90%, MTTR < 15 мин  \n",
+       "4              Снижение мошенничества ≥30%, ROI > 5%  "
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "roadmap = pd.DataFrame([\n",
+    "    {'Этап': '1. Подготовка (0-1 месяц)', 'Содержание': 'Настройка Kafka, Object Storage, загрузка исторических данных', 'Метрики успеха': 'Время загрузки < 10 мин, покрытие 100% данных'},\n",
+    "    {'Этап': '2. Стриминг-пайплайн (1-3 месяц)', 'Содержание': 'Разработка Flink job, реализация late data handling, чекпойнты', 'Метрики успеха': 'Задержка < 50 мс на 95-й перцентиль, падение <1% пакетов'},\n",
+    "    {'Этап': '3. ML и витрины (3-4 месяц)', 'Содержание': 'Фиче-стор, обучение модели, онлайн-инференс API', 'Метрики успеха': 'ROC AUC > 0.98, время инференса < 40 мс'},\n",
+    "    {'Этап': '4. Data Quality & мониторинг (4-5 месяц)', 'Содержание': 'Airflow DAG, Great Expectations, алерты', 'Метрики успеха': 'Покрытие проверками > 90%, MTTR < 15 мин'},\n",
+    "    {'Этап': '5. Эксплуатация и оптимизация (5-6 месяц)', 'Содержание': 'A/B тестирование, тюнинг параметров, отчёт по ROI', 'Метрики успеха': 'Снижение мошенничества ≥30%, ROI > 5%'},\n",
+    "])\n",
+    "\n",
+    "roadmap\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fac90e5",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**Критические риски и их минимизация.**\n",
+    "- *Late-arriving данные*: использовать watermark и reprocessing окон, хранить сырой поток в Kafka до 7 суток.\n",
+    "- *Дисбаланс классов*: применять stratified sampling, cost-sensitive loss, мониторить drift.\n",
+    "- *Регуляторные требования*: логирование решений модели, explainability (SHAP), хранение данных в соответствии с 152-ФЗ.\n",
+    "- *Отказы инфраструктуры*: multi-AZ развёртывание Kafka/Flink, автоматические рестарты, SLA-наблюдение через Prometheus.\n",
+    "\n",
+    "**Итог.** Предложенное решение учитывает 5V: сжатие и горячее хранение (Volume), стриминг и отказоустойчивость (Velocity), управление схемой и фичами (Variety), регулярные проверки качества (Veracity) и измеримый экономический эффект с положительным ROI (Value).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/build_notebook.py
+++ b/build_notebook.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import nbformat as nbf
+from textwrap import dedent
+
+nb = nbf.v4.new_notebook()
+cells = []
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+# Анализ 5V для сценария Fraud Detection
+
+Выбран датасет [Credit Card Fraud Detection](https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud) и бизнес-сценарий Fraud Detection: необходимо снизить количество мошеннических транзакций на 30% при ограничении задержки обработки до 50 мс и поддержке обработки late-arriving данных.
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+## Организация работы и воспроизводимость
+- Для запуска ноутбука требуется предварительно скачать файл `creditcard.csv` из датасета Kaggle и разместить его в папке `data/`.
+- В примерах используются библиотеки `pandas`, `numpy`, `pyarrow`, `fastavro`, `seaborn`, `matplotlib`, `great_expectations` и `scikit-learn`. При отсутствии их можно установить командой `pip install -r requirements.txt` (см. список в разделе импорта).
+- Все расчёты выполняются на оригинальном датасете без семплирования, чтобы сохранить дисбаланс классов, критичный для fraud detection.
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+from pathlib import Path
+import math
+from io import BytesIO
+import json
+
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from fastavro import writer, parse_schema
+
+import great_expectations as ge
+from great_expectations.execution_engine import PandasExecutionEngine
+from great_expectations.validator.validator import Validator
+from great_expectations.core.batch import Batch
+
+from IPython.display import Markdown, display
+
+plt.style.use('seaborn-v0_8')
+sns.set_theme(style='whitegrid')
+
+DATA_PATH = Path('data/creditcard.csv')
+if not DATA_PATH.exists():
+    raise FileNotFoundError('Файл data/creditcard.csv не найден. Скачайте датасет с Kaggle и поместите в папку data/.')
+
+df = pd.read_csv(DATA_PATH)
+df.head()
+""")))
+
+cells.append(nbf.v4.new_markdown_cell("""## 1. Volume (объём данных)"""))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+num_rows, num_cols = df.shape
+csv_size_bytes = DATA_PATH.stat().st_size
+avg_bytes_per_row = csv_size_bytes / num_rows
+
+parquet_buffer = BytesIO()
+pq.write_table(pa.Table.from_pandas(df), parquet_buffer, compression='snappy')
+parquet_size_bytes = parquet_buffer.getbuffer().nbytes
+
+avro_fields = []
+for col, dtype in zip(df.columns, df.dtypes):
+    if np.issubdtype(dtype, np.integer):
+        avro_type = 'long'
+    else:
+        avro_type = 'double'
+    avro_fields.append({'name': col, 'type': avro_type})
+
+avro_schema = {
+    'doc': 'Credit card transaction record',
+    'name': 'CreditCardRecord',
+    'namespace': 'fraud',
+    'type': 'record',
+    'fields': avro_fields,
+}
+
+avro_buffer = BytesIO()
+writer(avro_buffer, parse_schema(avro_schema), df.to_dict('records'))
+avro_size_bytes = avro_buffer.getbuffer().nbytes
+
+storage_formats = pd.DataFrame([
+    {
+        'Формат': 'CSV',
+        'Размер, МБ': csv_size_bytes / 1024**2,
+        'Коэффициент сжатия к CSV': 1.0,
+    },
+    {
+        'Формат': 'Parquet (Snappy)',
+        'Размер, МБ': parquet_size_bytes / 1024**2,
+        'Коэффициент сжатия к CSV': parquet_size_bytes / csv_size_bytes,
+    },
+    {
+        'Формат': 'Avro',
+        'Размер, МБ': avro_size_bytes / 1024**2,
+        'Коэффициент сжатия к CSV': avro_size_bytes / csv_size_bytes,
+    },
+]).set_index('Формат')
+
+volume_stats = {
+    'csv_size_bytes': csv_size_bytes,
+    'parquet_size_bytes': parquet_size_bytes,
+    'avro_size_bytes': avro_size_bytes,
+    'avg_bytes_per_row': avg_bytes_per_row,
+}
+
+storage_formats.round({'Размер, МБ': 2, 'Коэффициент сжатия к CSV': 3})
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+seconds_per_day = 24 * 3600
+adjusted_time = df['Time'] - df['Time'].min()
+day_index = np.floor(adjusted_time / seconds_per_day).astype(int)
+daily_counts = day_index.value_counts().sort_index()
+
+daily_volume_mb = daily_counts * volume_stats['avg_bytes_per_row'] / 1024**2
+
+daily_growth = (
+    pd.DataFrame({
+        'day_index': daily_counts.index,
+        'transactions': daily_counts.values,
+        'daily_volume_mb': daily_volume_mb.values,
+    })
+    .sort_values('day_index')
+    .reset_index(drop=True)
+)
+
+daily_growth['cumulative_volume_mb'] = daily_growth['daily_volume_mb'].cumsum()
+start_timestamp = pd.Timestamp('2013-01-01')
+daily_growth['date'] = start_timestamp + pd.to_timedelta(daily_growth['day_index'], unit='D')
+
+avg_daily_mb = daily_growth['daily_volume_mb'].mean()
+yearly_volume_gb = avg_daily_mb * 365 / 1024
+months_to_tb = (1024 * 1024) / avg_daily_mb / (365 / 12)
+
+volume_stats.update({
+    'avg_daily_mb': avg_daily_mb,
+    'yearly_volume_gb': yearly_volume_gb,
+    'months_to_tb': months_to_tb,
+})
+
+daily_growth
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+fig, ax = plt.subplots(figsize=(8, 4))
+sns.lineplot(data=daily_growth, x='date', y='cumulative_volume_mb', marker='o', ax=ax)
+ax.set_title('Кумулятивный рост объёма данных')
+ax.set_xlabel('Дата')
+ax.set_ylabel('Объём, МБ')
+plt.xticks(rotation=30)
+plt.tight_layout()
+plt.show()
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent('''
+summary_md = f"""
+- **Размер исходного CSV:** {volume_stats['csv_size_bytes'] / 1024**2:.2f} МБ (~{num_rows} записей).
+- **Средний объём данных за день:** {volume_stats['avg_daily_mb']:.2f} МБ, что даёт {volume_stats['yearly_volume_gb']:.2f} ГБ в год.
+- **Порог 1 ТБ будет достигнут примерно через:** {volume_stats['months_to_tb']:.1f} месяцев при текущей скорости роста (~40 лет).
+"""
+display(Markdown(summary_md))
+''')))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+cost_per_gb_month = 1.2  # RUB, тариф Yandex Object Storage Standard (предположение)
+yearly_storage_cost_rub = volume_stats['yearly_volume_gb'] * cost_per_gb_month * 12
+
+spark_threshold_gb = 5
+spark_days = spark_threshold_gb * 1024 / volume_stats['avg_daily_mb']
+
+cost_table = pd.DataFrame([
+    {'Показатель': 'Годовой объём (Parquet)', 'Значение': f"{volume_stats['yearly_volume_gb']:.2f} ГБ"},
+    {'Показатель': 'Стоимость хранения за год', 'Значение': f"{yearly_storage_cost_rub:,.0f} ₽"},
+    {'Показатель': 'Дней до накопления ~5 ГБ', 'Значение': f"{spark_days:.0f} дней"},
+])
+
+volume_stats['yearly_storage_cost_rub'] = yearly_storage_cost_rub
+volume_stats['spark_days'] = spark_days
+
+cost_table
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+**Горячие vs холодные данные.** При среднем объёме ~72 МБ/сутки целесообразно хранить последние 30 дней (~2.1 ГБ) в оперативно доступном слое (например, в объектном хранилище + таблицы Delta Lake) для онлайн-моделей. Исторические данные старше 90 дней можно архивировать в холодное хранилище (Iceberg/Glacier) с более дешёвым тарифом, сохранив возможность периодического переобучения.
+
+**Переход от Pandas к Spark.** Порог ~5 ГБ (~9.6 млн строк) будет достигнут через ~71 дней. Для обучения и инференса модели, учитывающей temporal features, уже на горизонте квартала рационально планировать миграцию на распределённую обработку (Spark/Flink), чтобы выдержать рост и расширение фич.
+""")))
+
+cells.append(nbf.v4.new_markdown_cell("""## 2. Velocity (скорость поступления данных)"""))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+base_time = pd.Timestamp('2013-01-01')
+df_time = df.assign(event_time=base_time + pd.to_timedelta(df['Time'], unit='s'))
+
+per_second = df_time.set_index('event_time').resample('1s').size()
+full_range = pd.date_range(per_second.index.min(), per_second.index.max(), freq='1s')
+per_second_full = per_second.reindex(full_range, fill_value=0)
+
+per_second_stats = {
+    'mean_rps': per_second_full.mean(),
+    'std_rps': per_second_full.std(ddof=0),
+    'cv': per_second_full.std(ddof=0) / per_second_full.mean(),
+}
+
+per_five_min = df_time.set_index('event_time').resample('5min').size()
+per_hour = df_time.set_index('event_time').resample('1H').size()
+
+velocity_table = pd.DataFrame([
+    {'Метрика': 'Среднее событий/сек', 'Значение': f"{per_second_stats['mean_rps']:.2f}"},
+    {'Метрика': 'Std событий/сек', 'Значение': f"{per_second_stats['std_rps']:.2f}"},
+    {'Метрика': 'Коэффициент вариации', 'Значение': f"{per_second_stats['cv']:.2f}"},
+    {'Метрика': 'Пиковая нагрузка (5 мин окно)', 'Значение': int(per_five_min.max())},
+    {'Метрика': 'Среднее событий/час', 'Значение': f"{per_hour.mean():.0f}"},
+    {'Метрика': 'Максимум событий/час', 'Значение': int(per_hour.max())},
+])
+
+velocity_stats = {
+    'per_second_series': per_second_full,
+    'per_five_min_series': per_five_min,
+    'per_hour_series': per_hour,
+    'peak_5min': int(per_five_min.max()),
+}
+
+velocity_table
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+fig, ax = plt.subplots(figsize=(9, 4))
+per_hour_plot = per_hour.reset_index(name='transactions')
+sns.lineplot(data=per_hour_plot, x='event_time', y='transactions', ax=ax)
+ax.set_title('Распределение транзакций по часам')
+ax.set_xlabel('Время')
+ax.set_ylabel('Количество транзакций')
+plt.xticks(rotation=30)
+plt.tight_layout()
+plt.show()
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+batch_latency = 60 * 60  # сек
+micro_batch_latency = 5 * 60
+stream_latency = 2  # предполагаемый SLA на обработку true streaming
+
+latency_table = pd.DataFrame([
+    {'Режим обработки': 'Batch (каждый час)', 'Ожидаемая задержка, сек': batch_latency, 'Комментарий': 'Слишком поздно для онлайнового антифрода'},
+    {'Режим обработки': 'Микробатчи (5 минут)', 'Ожидаемая задержка, сек': micro_batch_latency, 'Комментарий': 'Допустимо для мониторинга, но не выполняет SLA 50 мс'},
+    {'Режим обработки': 'Стриминг (<50 мс)', 'Ожидаемая задержка, сек': stream_latency, 'Комментарий': 'Требует событийной архитектуры'},
+])
+
+latency_table
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+outage_minutes = 30
+lost_records = per_second_stats['mean_rps'] * outage_minutes * 60
+lost_volume_mb = lost_records * volume_stats['avg_bytes_per_row'] / 1024**2
+lost_amount = lost_records * df['Amount'].mean()
+
+velocity_stats.update({
+    'lost_records_30min': lost_records,
+    'lost_volume_mb_30min': lost_volume_mb,
+    'lost_amount_30min': lost_amount,
+})
+
+loss_table = pd.DataFrame([
+    {'Показатель': 'Потерянные записи за 30 мин сбоя', 'Значение': f"{lost_records:,.0f}"},
+    {'Показатель': 'Объём потерянных данных', 'Значение': f"{lost_volume_mb:.2f} МБ"},
+    {'Показатель': 'Потенциальный ущерб (средний чек)', 'Значение': f"{lost_amount:,.0f}"},
+])
+
+loss_table
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+limit_ms = 50
+peak_rps = velocity_stats['peak_5min'] / (5 * 60)
+service_capacity_per_worker = 1000 / limit_ms
+headroom = 1.2  # 20% запас
+required_workers = math.ceil((peak_rps / service_capacity_per_worker) * headroom)
+
+resource_table = pd.DataFrame([
+    {'Показатель': 'Пиковая нагрузка, событий/сек', 'Значение': f"{peak_rps:.2f}"},
+    {'Показатель': 'Пропускная способность 1 воркера', 'Значение': f"{service_capacity_per_worker:.1f} событий/сек"},
+    {'Показатель': 'Необходимое количество воркеров', 'Значение': required_workers},
+])
+
+velocity_stats['required_workers'] = required_workers
+
+resource_table
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+**Вывод по Velocity.** При среднем потоке ~1.65 события/сек и пиках до 4.6 события/сек режим batch или микробатч приводит к задержке от минут до часа. Для выполнения SLA 50 мс необходим true streaming-процессинг (Flink/Spark Structured Streaming) с минимум двумя воркерами (один + резерв) и буферизацией поздних событий через Kafka. Сбой в 30 минут потенциально стоит ~262 тыс. у.е., поэтому критичен контроль отказоустойчивости и репликации.
+""")))
+
+cells.append(nbf.v4.new_markdown_cell("""## 3. Variety (разнообразие данных)"""))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+dtype_summary = pd.DataFrame({
+    'Колонка': df.columns,
+    'Тип': [str(t) for t in df.dtypes],
+    'Уникальных значений': df.nunique().values,
+    'Есть пропуски': df.isna().any().values,
+})
+
+dtype_summary
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent('''
+example_record = df.iloc[0].to_dict()
+
+variety_md = f"""
+- Все {num_cols} полей — числовые (float/int), текстовых или полу-структурированных данных нет.
+- Колонка `Time` хранит секунды с начала сбора без таймзоны; для feature engineering требуется перевод в календарные признаки.
+- Колонки `V1`-`V28` — PCA-компоненты, название не несёт бизнес-смысла, важно сопровождать метаданными.
+- Обнаружено {df.duplicated().sum()} дубликатов строк, что указывает на необходимость дедупликации до загрузки в витрины.
+
+Пример записи:
+```json
+{json.dumps(example_record, indent=2)}
+```
+"""
+
+display(Markdown(variety_md))
+''')))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+**Работа с разнообразием.**
+- Неструктурированных данных нет, поэтому дополнительные NLP/гео-обработки не требуются.
+- Для временных паттернов нужно агрегировать по окнам (5 мин, час, сутки) и обогащать внешними источниками (часы, праздники, региональные особенности).
+- Схема хранения: сырые данные в Parquet (bronze), нормализованные фичи в Delta Lake (silver), агрегаты и фичи для модели — в Feature Store (gold).
+""")))
+
+cells.append(nbf.v4.new_markdown_cell("""## 4. Veracity (достоверность данных)"""))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+quality_table = pd.DataFrame([
+    {'Метрика качества': 'Пропуски по колонкам', 'Значение': f"{(df.isna().sum()==0).sum()} / {num_cols} колонок без пропусков"},
+    {'Метрика качества': 'Отрицательные суммы', 'Значение': (df['Amount'] < 0).sum()},
+    {'Метрика качества': 'Дубликаты строк', 'Значение': df.duplicated().sum()},
+    {'Метрика качества': 'Доля мошенничества', 'Значение': f"{df['Class'].mean()*100:.4f}%"},
+])
+
+quality_table
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+ctx = ge.get_context()
+engine = PandasExecutionEngine()
+batch = Batch(data=df)
+validator = Validator(execution_engine=engine, batches=[batch], data_context=ctx)
+
+ge_results = {
+    'No nulls in Time': validator.expect_column_values_to_not_be_null('Time'),
+    'Amount non-negative': validator.expect_column_values_to_be_between('Amount', min_value=0),
+    'Class is binary': validator.expect_column_values_to_be_in_set('Class', [0, 1]),
+}
+
+ge_summary = pd.DataFrame([
+    {
+        'Expectation': name,
+        'Success': result['success'],
+        'Unexpected %': result['result']['unexpected_percent'],
+    }
+    for name, result in ge_results.items()
+])
+
+ge_summary
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+**Воздействие проблем качества.** При ошибке меток даже на 1% (~2.8 тыс. транзакций) возможен рост FN и прямые потери >~0.6 млн у.е. Поэтому нужно:
+- выполнять дедупликацию и контроль меток до поступления в real-time поток,
+- ежедневно запускать data-quality проверки (Great Expectations + Airflow) и алерты на рост доли пропусков,
+- логировать поздние события и пересчитывать фичи ретроспективно.
+""")))
+
+cells.append(nbf.v4.new_markdown_cell("""## 5. Value (ценность данных)"""))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+total_transactions = len(df)
+total_fraud = int(df['Class'].sum())
+fraud_amount_total = df.loc[df['Class'] == 1, 'Amount'].sum()
+reduction_target = 0.30
+eur_to_rub = 100  # предположение о курсе EUR/RUB
+potential_savings_rub = fraud_amount_total * reduction_target * eur_to_rub
+
+compute_cost_rub = 2 * 18 * 24 * 365  # два стриминг-воркера по 18 ₽/час
+kafka_cost_rub = 6000 * 12  # управляемый кластер Kafka
+storage_cost_rub = volume_stats['yearly_storage_cost_rub']
+development_cost_rub = 2 * 220_000 * 3  # 2 инженера, 3 месяца
+
+annual_cost_rub = compute_cost_rub + kafka_cost_rub + storage_cost_rub + development_cost_rub
+roi = (potential_savings_rub - annual_cost_rub) / annual_cost_rub
+payback_months = annual_cost_rub / (potential_savings_rub / 12)
+
+value_table = pd.DataFrame([
+    {'Показатель': 'Количество транзакций', 'Значение': f"{total_transactions:,}"},
+    {'Показатель': 'Количество мошеннических транзакций', 'Значение': total_fraud},
+    {'Показатель': 'Сумма мошенничества (EUR)', 'Значение': f"{fraud_amount_total:,.2f}"},
+    {'Показатель': 'Цель (30%) — предотвращено, EUR', 'Значение': f"{fraud_amount_total * reduction_target:,.2f}"},
+    {'Показатель': 'Потенциальная выгода (RUB)', 'Значение': f"{potential_savings_rub:,.0f}"},
+    {'Показатель': 'Годовые затраты, RUB', 'Значение': f"{annual_cost_rub:,.0f}"},
+    {'Показатель': 'ROI', 'Значение': f"{roi*100:.1f}%"},
+    {'Показатель': 'Срок окупаемости', 'Значение': f"{payback_months:.1f} месяцев"},
+])
+
+value_stats = {
+    'potential_savings_rub': potential_savings_rub,
+    'annual_cost_rub': annual_cost_rub,
+    'roi': roi,
+    'payback_months': payback_months,
+}
+
+value_table
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+fraud_df = df.loc[df['Class'] == 1, ['Amount']].copy()
+fraud_df = fraud_df.sort_values('Amount', ascending=False)
+fraud_df['cum_amount'] = fraud_df['Amount'].cumsum()
+fraud_df['fraction_records'] = (np.arange(len(fraud_df)) + 1) / len(fraud_df)
+fraud_df['cum_amount_share'] = fraud_df['cum_amount'] / fraud_amount_total
+
+fig, ax = plt.subplots(figsize=(7, 4))
+sns.lineplot(data=fraud_df, x='fraction_records', y='cum_amount_share', ax=ax)
+ax.set_title('Ценность vs объём обработанных данных')
+ax.set_xlabel('Доля обработанных мошеннических транзакций')
+ax.set_ylabel('Кумулятивная доля предотвращённого ущерба')
+ax.axvline(0.2, color='red', linestyle='--', label='20% записей')
+ax.axhline(fraud_df.loc[fraud_df['fraction_records'] <= 0.2, 'cum_amount_share'].max(), color='gray', linestyle=':')
+ax.legend()
+plt.tight_layout()
+plt.show()
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+def categorize_abc(value):
+    if value <= 0.8:
+        return 'A'
+    elif value <= 0.95:
+        return 'B'
+    return 'C'
+
+fraud_df['abc_category'] = fraud_df['cum_amount_share'].apply(categorize_abc)
+abc_summary = fraud_df.groupby('abc_category').agg(
+    transactions=('Amount', 'count'),
+    value_share=('Amount', lambda x: x.sum() / fraud_amount_total),
+)
+abc_summary['transactions_share'] = abc_summary['transactions'] / abc_summary['transactions'].sum()
+abc_summary = abc_summary.rename(index={'A': 'A (top value)', 'B': 'B', 'C': 'C'}).reset_index()
+abc_summary
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+**Мониторинг ценности.**
+- Отслеживать precision/recall, FPR, долю предотвращённых сумм и факт возвратов каждые 15 минут.
+- Пересчитывать ROI ежеквартально, учитывая реальный курс валют и обновлённые тарифы инфраструктуры.
+- Через год при росте конкуренции и эволюции мошеннических схем ожидается повышение ценности данных: накопленные исторические последовательности позволят улучшить модели sequence modeling (LSTM/Transformers) и повысить recall на 3-5 п.п., что увеличит экономию.
+""")))
+
+cells.append(nbf.v4.new_markdown_cell("""## 6. Технологический стек и рекомендации"""))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+technology_table = pd.DataFrame([
+    {
+        'Слой': 'Хранилище сырых данных',
+        'Рекомендуемая технология': 'Yandex Object Storage + Delta Lake',
+        'Альтернативы': 'HDFS, S3, Iceberg',
+        'Обоснование': 'Дешёвое хранение, версионирование, поддержка ACID для апдейтов поздних событий',
+        'Риски': 'Стоимость запросов при горячем доступе, необходимость настроить версионирование',
+    },
+    {
+        'Слой': 'Стриминг',
+        'Рекомендуемая технология': 'Apache Kafka + Kafka Connect',
+        'Альтернативы': 'Pulsar, RabbitMQ',
+        'Обоснование': 'Гарантии доставки, re-play, поддержка late-arriving событий',
+        'Риски': 'Требует DevOps-поддержки и мониторинга лагов',
+    },
+    {
+        'Слой': 'Обработка',
+        'Рекомендуемая технология': 'Apache Flink (или Spark Structured Streaming)',
+        'Альтернативы': 'Kafka Streams, Storm',
+        'Обоснование': 'Низкая задержка <50 мс, stateful стриминг, windows',
+        'Риски': 'Сложность отладки stateful-джобов, необходимость чекпойнтов',
+    },
+    {
+        'Слой': 'ML/Feature Store',
+        'Рекомендуемая технология': 'Feast + MLflow',
+        'Альтернативы': 'Hopsworks, Tecton',
+        'Обоснование': 'Повторное использование фич онлайн/оффлайн, версионирование моделей',
+        'Риски': 'Интеграция с онлайн-хранилищем (Redis/ClickHouse)',
+    },
+    {
+        'Слой': 'Оркестрация и качество',
+        'Рекомендуемая технология': 'Apache Airflow + Great Expectations',
+        'Альтернативы': 'Prefect, Dagster',
+        'Обоснование': 'Планирование DAG, запуск data-quality чеков, SLA мониторинг',
+        'Риски': 'Нагрузка на scheduler, необходимость резервирования metadata DB',
+    },
+])
+
+technology_table
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent(r"""
+```mermaid
+flowchart LR
+    subgraph Ingestion
+        A[Сырые транзакции] -->|REST/API| B[Kafka]
+        B --> C[Kafka Connect]
+    end
+    subgraph Processing
+        C --> D[Apache Flink Streaming]
+        D -->|Features| E[Feature Store (Feast)]
+        D -->|Alerts| F[Fraud API]
+    end
+    subgraph Storage
+        D --> G[Delta Lake / Object Storage]
+        E --> H[MLflow Model Registry]
+        H --> F
+    end
+    subgraph Monitoring
+        D --> I[Prometheus/Grafana]
+        G --> J[Airflow + Great Expectations]
+    end
+```
+""")))
+
+cells.append(nbf.v4.new_code_cell(dedent("""
+roadmap = pd.DataFrame([
+    {'Этап': '1. Подготовка (0-1 месяц)', 'Содержание': 'Настройка Kafka, Object Storage, загрузка исторических данных', 'Метрики успеха': 'Время загрузки < 10 мин, покрытие 100% данных'},
+    {'Этап': '2. Стриминг-пайплайн (1-3 месяц)', 'Содержание': 'Разработка Flink job, реализация late data handling, чекпойнты', 'Метрики успеха': 'Задержка < 50 мс на 95-й перцентиль, падение <1% пакетов'},
+    {'Этап': '3. ML и витрины (3-4 месяц)', 'Содержание': 'Фиче-стор, обучение модели, онлайн-инференс API', 'Метрики успеха': 'ROC AUC > 0.98, время инференса < 40 мс'},
+    {'Этап': '4. Data Quality & мониторинг (4-5 месяц)', 'Содержание': 'Airflow DAG, Great Expectations, алерты', 'Метрики успеха': 'Покрытие проверками > 90%, MTTR < 15 мин'},
+    {'Этап': '5. Эксплуатация и оптимизация (5-6 месяц)', 'Содержание': 'A/B тестирование, тюнинг параметров, отчёт по ROI', 'Метрики успеха': 'Снижение мошенничества ≥30%, ROI > 5%'},
+])
+
+roadmap
+""")))
+
+cells.append(nbf.v4.new_markdown_cell(dedent("""
+**Критические риски и их минимизация.**
+- *Late-arriving данные*: использовать watermark и reprocessing окон, хранить сырой поток в Kafka до 7 суток.
+- *Дисбаланс классов*: применять stratified sampling, cost-sensitive loss, мониторить drift.
+- *Регуляторные требования*: логирование решений модели, explainability (SHAP), хранение данных в соответствии с 152-ФЗ.
+- *Отказы инфраструктуры*: multi-AZ развёртывание Kafka/Flink, автоматические рестарты, SLA-наблюдение через Prometheus.
+
+**Итог.** Предложенное решение учитывает 5V: сжатие и горячее хранение (Volume), стриминг и отказоустойчивость (Velocity), управление схемой и фичами (Variety), регулярные проверки качества (Veracity) и измеримый экономический эффект с положительным ROI (Value).
+""")))
+
+nb['cells'] = cells
+nb['metadata'] = {
+    'kernelspec': {
+        'display_name': 'Python 3',
+        'language': 'python',
+        'name': 'python3'
+    },
+    'language_info': {
+        'name': 'python',
+        'version': '3.12'
+    }
+}
+
+nbf.write(nb, 'Fraud_Detection_5V.ipynb')


### PR DESCRIPTION
## Summary
- add an executed Jupyter notebook with full 5V analysis of the credit card fraud dataset for the fraud detection scenario
- include calculations for storage footprint, streaming velocity, data quality, business ROI, technology stack and roadmap
- add helper script to regenerate the notebook and ignore local data artifacts

## Testing
- python - <<'PY'
import nbformat
from nbclient import NotebookClient

nb_path = 'Fraud_Detection_5V.ipynb'
nb = nbformat.read(nb_path, as_version=4)
client = NotebookClient(nb, timeout=1200, kernel_name='python3', allow_errors=False)
client.execute()
nbformat.write(nb, nb_path)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cbe30005888324bda73f0fa01ab9c9